### PR TITLE
fix: make showtime creation retry-safe

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
         // Temporal 워크플로 본문은 `bundleWorkflowCode`가 만든 샌드박스 안에서 실행된다.
         // 그 안에서는 Jest의 Istanbul 계측이 닿지 않으므로, 통합 테스트를 실행해도 0%로 기록된다.
         // 순수 로직은 옆 파일로 분리해 단위 테스트로 따로 덮는다.
-        '/worker/workflow\\.ts$'
+        '/worker/workflow(?:-v2)?\\.ts$'
     ],
     coverageDirectory: '<rootDir>/_output/coverage'
 }

--- a/apps/api/scripts/bundle-workflows.ts
+++ b/apps/api/scripts/bundle-workflows.ts
@@ -1,9 +1,12 @@
 import { bundleWorkflowCode } from '@temporalio/worker'
 import fs from 'fs'
 import path from 'path'
-import { showtimeCreationBundle } from '../src/services/application/showtime-creation/worker/bundle'
+import {
+    legacyShowtimeCreationBundle,
+    showtimeCreationBundle
+} from '../src/services/application/showtime-creation/worker/bundle'
 
-const workflows = [showtimeCreationBundle]
+const workflows = [legacyShowtimeCreationBundle, showtimeCreationBundle]
 
 async function bundleWorkflows(): Promise<void> {
     for (const { sourcePath, bundlePath } of workflows) {

--- a/apps/api/src/__tests__/application/showtime-creation.spec.ts
+++ b/apps/api/src/__tests__/application/showtime-creation.spec.ts
@@ -1,5 +1,10 @@
+import type {
+    LegacyShowtimeCreationActivities,
+    ShowtimeBulkValidatorService,
+    ShowtimeCreationPersistenceService
+} from 'application'
 import type { MovieDto, ShowtimesService, TheaterDto, TicketsService } from 'core'
-import { DateUtil, JsonUtil, sleep } from '@mannercode/common'
+import { DateUtil, JsonUtil, newObjectIdString, sleep } from '@mannercode/common'
 import { HttpTestClient, nullObjectId, type Response } from '@mannercode/testing'
 import {
     createMovie,
@@ -14,21 +19,39 @@ describe('ShowtimeCreationService', () => {
     let fix: AppTestContext
     let showtimesService: ShowtimesService
     let ticketsService: TicketsService
+    let persistence: ShowtimeCreationPersistenceService
+    let validatorService: ShowtimeBulkValidatorService
+    let legacyActivities: LegacyShowtimeCreationActivities
     let movie: MovieDto
     let theater: TheaterDto
 
     beforeEach(async () => {
         const { createAppTestContext } = await import('../helpers')
         const { ShowtimesService, TicketsService } = await import('core')
+        const {
+            LegacyShowtimeCreationActivities,
+            ShowtimeBulkValidatorService,
+            ShowtimeCreationPersistenceService
+        } = await import('application')
         const { AdminAuthGuard } = await import('gateway')
         fix = await createAppTestContext({ ignoreGuards: [AdminAuthGuard] })
         showtimesService = fix.module.get(ShowtimesService)
         ticketsService = fix.module.get(TicketsService)
+        persistence = fix.module.get(ShowtimeCreationPersistenceService)
+        validatorService = fix.module.get(ShowtimeBulkValidatorService)
+        legacyActivities = fix.module.get(LegacyShowtimeCreationActivities)
 
         movie = await createMovie(fix)
         theater = await createTheater(fix)
     })
     afterEach(() => fix.teardown())
+
+    const buildCreateDto = () => ({
+        durationInMinutes: 1,
+        movieId: movie.id,
+        startTimes: [new Date('2100-01-01T09:00')],
+        theaterIds: [theater.id]
+    })
 
     describe('GET /showtime-creation/movies', () => {
         it('쿼리가 없으면 전체 영화 페이지를 반환한다', async () => {
@@ -263,95 +286,211 @@ describe('ShowtimeCreationService', () => {
                 .badRequest(Errors.ShowtimeCreation.OverlappingStartTimes(expect.any(Array)))
         })
 
-        describe('생성 도중 티켓 생성이 실패하면', () => {
-            // 상영 시간은 모두 저장되고, 티켓은 일부 묶음까지 저장된 뒤 다음 묶음에서 던진다.
-            // 검증에서 멈추는 위의 오류 케이스와 달리 상영 시간·티켓 행이 실제로 남은 뒤 실패하므로,
-            // 보상이 상영 시간과 티켓을 모두 되돌리는 경로를 검증한다.
+        describe('트랜잭션 안에서 티켓을 저장한 뒤 실패하면', () => {
             let sagaId: string
             let createShowtimesSpy: jest.SpyInstance
-            let persistedTicketCount: number
+            let attemptedTicketCount: number
 
             beforeEach(async () => {
-                persistedTicketCount = 0
-                // 상영 시간 생성은 통과시키되 호출을 관찰한다.
+                attemptedTicketCount = 0
                 createShowtimesSpy = jest.spyOn(showtimesService, 'createMany')
 
-                // 첫 티켓 묶음은 실제로 적재하고, 그 적재가 끝난 뒤 다음 묶음에서 실패시킨다.
-                // 일부 티켓이 DB에 남은 상태로 보상이 돌게 해야 '티켓 삭제' 단언이 헛돌지 않는다.
+                // 실제 insert까지 실행한 다음 throw한다. transaction이 없으면 showtimes와 tickets가 남는다.
                 const realCreateMany = ticketsService.createMany.bind(ticketsService)
-                let firstBatch: ReturnType<typeof realCreateMany> | undefined
-                jest.spyOn(ticketsService, 'createMany').mockImplementation(async (createDtos) => {
-                    if (!firstBatch) {
-                        firstBatch = realCreateMany(createDtos)
-                        const result = await firstBatch
-                        persistedTicketCount = result.count
-                        return result
+                jest.spyOn(ticketsService, 'createMany').mockImplementation(
+                    async (createDtos, session, signal) => {
+                        await realCreateMany(createDtos, session, signal)
+                        attemptedTicketCount += createDtos.length
+                        throw new Error('ticket creation failed after insert')
                     }
-                    // 첫 묶음이 커밋된 뒤에 던져, 보상 시점에 지울 티켓이 반드시 존재하게 한다.
-                    await firstBatch
-                    throw new Error('ticket creation failed')
-                })
+                )
 
                 const completionPromise = waitForCompletion(fix, 'error')
                 const { body } = await fix.httpClient
                     .post('/showtime-creation/showtimes')
                     .body({
-                        durationInMinutes: 1,
-                        movieId: movie.id,
-                        startTimes: [new Date('2100-01-01T09:00'), new Date('2100-01-01T11:00')],
-                        theaterIds: [theater.id]
+                        ...buildCreateDto(),
+                        startTimes: [new Date('2100-01-01T09:00'), new Date('2100-01-01T11:00')]
                     })
                     .accepted()
                 sagaId = body.sagaId
                 await completionPromise
             })
 
-            it('롤백 대상이 되도록 상영 시간과 티켓을 실제로 먼저 생성한다', () => {
-                // 보상 검증이 빈 상태를 빈 상태로 비교하는 헛돌이가 되지 않도록, 되돌릴 대상이 만들어졌는지 먼저 확인한다.
-                expect(createShowtimesSpy.mock.calls[0][0]).not.toHaveLength(0)
-                expect(persistedTicketCount).toBeGreaterThan(0)
+            it('Temporal 재시도마다 생성 쓰기까지 실제로 실행한다', () => {
+                expect(createShowtimesSpy).toHaveBeenCalledTimes(4)
+                expect(attemptedTicketCount).toBeGreaterThan(0)
             })
 
-            it('보상으로 생성된 상영 시간을 모두 삭제한다', async () => {
+            it('실패한 transaction의 상영 시간과 티켓을 모두 롤백한다', async () => {
                 const showtimes = await showtimesService.search({ sagaIds: [sagaId] })
-                expect(showtimes).toEqual([])
-            })
-
-            it('보상으로 생성된 티켓을 모두 삭제한다', async () => {
                 const tickets = await ticketsService.search({ sagaIds: [sagaId] })
+                expect(showtimes).toEqual([])
                 expect(tickets).toEqual([])
             })
         })
 
-        describe('보상 중 삭제가 한 번 실패하면', () => {
-            // compensate는 실패를 던져 Temporal 재시도 정책에 맡긴다. 삭제는 멱등이라 재실행이 안전하다.
-            beforeEach(() => {
-                jest.spyOn(ticketsService, 'createMany').mockRejectedValueOnce(
-                    new Error('ticket creation failed')
+        it('티켓 저장이 한 번 실패해도 Activity 재시도로 한 세트만 생성한다', async () => {
+            jest.spyOn(ticketsService, 'createMany').mockRejectedValueOnce(
+                new Error('transient ticket write failure')
+            )
+
+            const completionPromise = waitForCompletion(fix, 'succeeded')
+            const { body } = await fix.httpClient
+                .post('/showtime-creation/showtimes')
+                .body(buildCreateDto())
+                .accepted()
+            const completion = await completionPromise
+
+            const showtimes = await showtimesService.search({ sagaIds: [body.sagaId] })
+            const tickets = await ticketsService.search({ sagaIds: [body.sagaId] })
+            expect(showtimes).toHaveLength(completion.createdShowtimeCount)
+            expect(tickets).toHaveLength(completion.createdTicketCount)
+        })
+
+        it('커밋 뒤 첫 완료 보고를 잃어도 재시도가 저장 결과를 읽어 중복 없이 성공한다', async () => {
+            const realValidateAndCreate = persistence.validateAndCreate.bind(persistence)
+            const persistenceSpy = jest
+                .spyOn(persistence, 'validateAndCreate')
+                .mockImplementationOnce(async (...args) => {
+                    // 실제 Activity heartbeat interval이 한 번 실행되는 장기 작업 경로도 함께 검증한다.
+                    await sleep(5_100)
+                    await realValidateAndCreate(...args)
+                    throw new Error('activity completion response lost after commit')
+                })
+            const createShowtimesSpy = jest.spyOn(showtimesService, 'createMany')
+
+            const completionPromise = waitForCompletion(fix, 'succeeded')
+            const { body } = await fix.httpClient
+                .post('/showtime-creation/showtimes')
+                .body(buildCreateDto())
+                .accepted()
+            const completion = await completionPromise
+
+            expect(persistenceSpy).toHaveBeenCalledTimes(2)
+            expect(createShowtimesSpy).toHaveBeenCalledTimes(1)
+            const showtimes = await showtimesService.search({ sagaIds: [body.sagaId] })
+            const tickets = await ticketsService.search({ sagaIds: [body.sagaId] })
+            expect(showtimes).toHaveLength(completion.createdShowtimeCount)
+            expect(tickets).toHaveLength(completion.createdTicketCount)
+        })
+
+        it('같은 saga를 순차 재실행하면 저장된 결과를 반환하고 중복 생성하지 않는다', async () => {
+            const sagaId = newObjectIdString()
+            const createDto = buildCreateDto()
+
+            const first = await persistence.validateAndCreate(createDto, sagaId)
+            const second = await persistence.validateAndCreate(createDto, sagaId)
+
+            expect(second).toEqual(first)
+            expect(first.kind).toBe('succeeded')
+            const showtimes = await showtimesService.search({ sagaIds: [sagaId] })
+            const tickets = await ticketsService.search({ sagaIds: [sagaId] })
+            if (first.kind === 'succeeded') {
+                expect(showtimes).toHaveLength(first.createdShowtimeCount)
+                expect(tickets).toHaveLength(first.createdTicketCount)
+            }
+        })
+
+        it('완료된 sagaId를 다른 입력으로 재사용하면 거부한다', async () => {
+            const sagaId = newObjectIdString()
+            const createDto = buildCreateDto()
+            await persistence.validateAndCreate(createDto, sagaId)
+
+            await expect(
+                persistence.validateAndCreate(
+                    { ...createDto, startTimes: [new Date('2100-01-01T11:00')] },
+                    sagaId
                 )
-                jest.spyOn(ticketsService, 'deleteBySagaIds').mockRejectedValueOnce(
-                    new Error('delete failed')
+            ).rejects.toThrow(`Saga ID was reused with different input (sagaId=${sagaId})`)
+        })
+
+        it('한 operation의 상영 시간 수가 안전 상한을 넘으면 transaction 전에 거부한다', async () => {
+            const createDto = {
+                ...buildCreateDto(),
+                startTimes: Array.from(
+                    { length: 15 },
+                    (_, index) => new Date(Date.UTC(2100, 0, 1, index))
+                ),
+                theaterIds: Array.from({ length: 15 }, () => newObjectIdString())
+            }
+
+            await expect(
+                persistence.validateAndCreate(createDto, newObjectIdString())
+            ).rejects.toMatchObject({
+                response: { code: 'ERR_SHOWTIME_CREATION_TOO_MANY_SHOWTIMES', maximum: 200 }
+            })
+        })
+
+        it('좌석 티켓 수가 안전 상한을 넘으면 showtime insert도 롤백한다', async () => {
+            const largeTheater = await createTheater(fix, {
+                seatmap: {
+                    blocks: [{ name: 'A', rows: [{ name: '1', layout: 'O'.repeat(10_001) }] }]
+                }
+            })
+            const sagaId = newObjectIdString()
+
+            await expect(
+                persistence.validateAndCreate(
+                    { ...buildCreateDto(), theaterIds: [largeTheater.id] },
+                    sagaId
                 )
+            ).rejects.toMatchObject({
+                response: { code: 'ERR_SHOWTIME_CREATION_TOO_MANY_TICKETS', maximum: 10_000 }
+            })
+            await expect(showtimesService.search({ sagaIds: [sagaId] })).resolves.toEqual([])
+        })
+
+        it('drain 중인 v1 Activity도 기존 비-transaction 호출 경로로 생성하고 보상한다', async () => {
+            const sagaId = newObjectIdString()
+            const result = await legacyActivities.validateAndCreate({
+                createDto: buildCreateDto(),
+                sagaId
             })
 
-            it('재시도로 정리를 끝낸 뒤 오류 상태를 전송한다', async () => {
-                const completionPromise = waitForCompletion(fix, 'error')
+            expect(result.kind).toBe('succeeded')
+            await legacyActivities.compensate(sagaId)
+            await expect(showtimesService.search({ sagaIds: [sagaId] })).resolves.toEqual([])
+            await expect(ticketsService.search({ sagaIds: [sagaId] })).resolves.toEqual([])
+        })
 
-                const { body } = await fix.httpClient
-                    .post('/showtime-creation/showtimes')
-                    .body({
-                        durationInMinutes: 1,
-                        movieId: movie.id,
-                        startTimes: [new Date('2100-01-01T09:00')],
-                        theaterIds: [theater.id]
-                    })
-                    .accepted()
-
-                await completionPromise
-
-                const showtimes = await showtimesService.search({ sagaIds: [body.sagaId] })
-                expect(showtimes).toEqual([])
+        it('v1 validator도 존재하지 않는 극장을 거부한다', async () => {
+            await expect(
+                validatorService.validate({ ...buildCreateDto(), theaterIds: [nullObjectId] })
+            ).rejects.toMatchObject({
+                response: { code: 'ERR_SHOWTIME_CREATION_THEATERS_NOT_FOUND' }
             })
+        })
+
+        it('같은 saga를 동시에 재실행해도 두 호출이 같은 한 세트에 수렴한다', async () => {
+            const sagaId = newObjectIdString()
+            const createDto = buildCreateDto()
+
+            const [first, second] = await Promise.all([
+                persistence.validateAndCreate(createDto, sagaId),
+                persistence.validateAndCreate(createDto, sagaId)
+            ])
+
+            expect(second).toEqual(first)
+            const showtimes = await showtimesService.search({ sagaIds: [sagaId] })
+            const tickets = await ticketsService.search({ sagaIds: [sagaId] })
+            if (first.kind === 'succeeded') {
+                expect(showtimes).toHaveLength(first.createdShowtimeCount)
+                expect(tickets).toHaveLength(first.createdTicketCount)
+            }
+        })
+
+        it('같은 극장의 겹치는 두 saga를 동시에 실행하면 정확히 하나만 생성한다', async () => {
+            const createDto = buildCreateDto()
+            const sagaIds = [newObjectIdString(), newObjectIdString()]
+
+            const results = await Promise.all(
+                sagaIds.map((sagaId) => persistence.validateAndCreate(createDto, sagaId))
+            )
+
+            expect(results.map((result) => result.kind).sort()).toEqual(['failed', 'succeeded'])
+            const showtimes = await showtimesService.search({ sagaIds })
+            expect(showtimes).toHaveLength(1)
         })
 
         it('기존 상영 시간과 겹치면 충돌 목록과 함께 실패 상태를 전송한다', async () => {

--- a/apps/api/src/services/application/showtime-creation/dtos/bulk-create-showtimes.dto.ts
+++ b/apps/api/src/services/application/showtime-creation/dtos/bulk-create-showtimes.dto.ts
@@ -1,5 +1,14 @@
 import { Type } from 'class-transformer'
-import { ArrayNotEmpty, IsArray, IsDate, IsNotEmpty, IsPositive, IsString } from 'class-validator'
+import {
+    ArrayNotEmpty,
+    ArrayMaxSize,
+    ArrayUnique,
+    IsArray,
+    IsDate,
+    IsNotEmpty,
+    IsPositive,
+    IsString
+} from 'class-validator'
 
 export class BulkCreateShowtimesDto {
     @IsNotEmpty()
@@ -11,12 +20,15 @@ export class BulkCreateShowtimesDto {
     movieId: string
 
     @ArrayNotEmpty()
+    @ArrayMaxSize(20)
     @IsArray()
     @IsDate({ each: true })
     @Type(() => Date)
     startTimes: Date[]
 
     @ArrayNotEmpty()
+    @ArrayMaxSize(20)
+    @ArrayUnique()
     @IsArray()
     @IsString({ each: true })
     theaterIds: string[]

--- a/apps/api/src/services/application/showtime-creation/errors.ts
+++ b/apps/api/src/services/application/showtime-creation/errors.ts
@@ -9,6 +9,16 @@ export const ShowtimeCreationErrors = {
         message: 'Some start times in the request overlap each other.',
         startTimes
     }),
+    TooManyShowtimes: (maximum: number) => ({
+        code: 'ERR_SHOWTIME_CREATION_TOO_MANY_SHOWTIMES',
+        maximum,
+        message: `A single request can create at most ${maximum} showtimes.`
+    }),
+    TooManyTickets: (maximum: number) => ({
+        code: 'ERR_SHOWTIME_CREATION_TOO_MANY_TICKETS',
+        maximum,
+        message: `A single request can create at most ${maximum} tickets.`
+    }),
     TheatersNotFound: (theaterIds: string[]) => ({
         code: 'ERR_SHOWTIME_CREATION_THEATERS_NOT_FOUND',
         message: 'One or more requested theaters could not be found.',

--- a/apps/api/src/services/application/showtime-creation/index.ts
+++ b/apps/api/src/services/application/showtime-creation/index.ts
@@ -1,5 +1,7 @@
 export * from './dtos'
 export * from './errors'
+export { ShowtimeBulkValidatorService, ShowtimeCreationPersistenceService } from './internal'
 export * from './showtime-creation.events'
 export * from './showtime-creation.module'
 export * from './showtime-creation.service'
+export { LegacyShowtimeCreationActivities } from './worker/legacy-activities'

--- a/apps/api/src/services/application/showtime-creation/internal/index.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/index.ts
@@ -1,4 +1,5 @@
 export * from './showtime-bulk-creator.service'
 export * from './showtime-bulk-validator.service'
 export * from './showtime-creation-orchestrator.service'
+export * from './showtime-creation-persistence.service'
 export * from './types'

--- a/apps/api/src/services/application/showtime-creation/internal/models/index.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/models/index.ts
@@ -1,0 +1,1 @@
+export * from './showtime-creation-operation'

--- a/apps/api/src/services/application/showtime-creation/internal/models/showtime-creation-operation.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/models/showtime-creation-operation.ts
@@ -1,0 +1,22 @@
+import { createCrudSchema, CrudSchema, HardDelete } from '@mannercode/common'
+import { Prop, Schema } from '@nestjs/mongoose'
+import { MONGOOSE_SCHEMA_OPTIONS } from 'config'
+import type { ValidateAndCreateResult } from '../types'
+
+@HardDelete()
+@Schema(MONGOOSE_SCHEMA_OPTIONS)
+export class ShowtimeCreationOperation extends CrudSchema {
+    @Prop({ required: true })
+    inputHash: string
+
+    @Prop({ required: true, type: Object })
+    result: ValidateAndCreateResult
+
+    @Prop({ required: true })
+    sagaId: string
+}
+
+export const ShowtimeCreationOperationSchema = createCrudSchema(ShowtimeCreationOperation)
+
+// 같은 saga의 Activity 재실행은 하나의 저장 결과에만 수렴한다.
+ShowtimeCreationOperationSchema.index({ sagaId: 1 }, { unique: true })

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-bulk-creator.service.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-bulk-creator.service.ts
@@ -1,5 +1,6 @@
+import type { ClientSession } from 'mongoose'
 import { DateUtil, Require, uniq } from '@mannercode/common'
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import {
     ShowtimeDto,
     ShowtimesService,
@@ -10,6 +11,9 @@ import {
     TicketStatus
 } from 'core'
 import { BulkCreateShowtimesDto } from '../dtos'
+import { ShowtimeCreationErrors } from '../errors'
+
+const MAX_TICKETS_PER_OPERATION = 10_000
 
 @Injectable()
 export class ShowtimeBulkCreatorService {
@@ -21,10 +25,20 @@ export class ShowtimeBulkCreatorService {
         private readonly ticketsService: TicketsService
     ) {}
 
-    async create(createDto: BulkCreateShowtimesDto, sagaId: string) {
-        const createdShowtimes = await this.bulkCreateShowtimes(createDto, sagaId)
+    async create(
+        createDto: BulkCreateShowtimesDto,
+        sagaId: string,
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        const createdShowtimes = await this.bulkCreateShowtimes(createDto, sagaId, session, signal)
 
-        const createdTicketCount = await this.bulkCreateTickets(createdShowtimes, sagaId)
+        const createdTicketCount = await this.bulkCreateTickets(
+            createdShowtimes,
+            sagaId,
+            session,
+            signal
+        )
 
         this.logger.log('create completed', {
             sagaId,
@@ -35,7 +49,12 @@ export class ShowtimeBulkCreatorService {
         return { createdShowtimeCount: createdShowtimes.length, createdTicketCount }
     }
 
-    private async bulkCreateShowtimes(createDto: BulkCreateShowtimesDto, sagaId: string) {
+    private async bulkCreateShowtimes(
+        createDto: BulkCreateShowtimesDto,
+        sagaId: string,
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
         const { durationInMinutes, movieId, startTimes, theaterIds } = createDto
 
         const createDtos = theaterIds.flatMap((theaterId) =>
@@ -48,40 +67,53 @@ export class ShowtimeBulkCreatorService {
             }))
         )
 
-        await this.showtimesService.createMany(createDtos)
-        const showtimes = await this.showtimesService.search({ sagaIds: [sagaId] })
+        await this.showtimesService.createMany(createDtos, session, signal)
+        const showtimes = await this.showtimesService.search({ sagaIds: [sagaId] }, session, signal)
         return showtimes
     }
 
-    private async bulkCreateTickets(showtimes: ShowtimeDto[], sagaId: string) {
-        let totalCount = 0
-
+    private async bulkCreateTickets(
+        showtimes: ShowtimeDto[],
+        sagaId: string,
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
         const theaterIds = uniq(showtimes.map((showtime) => showtime.theaterId))
-        const theaters = await this.theatersService.getMany(theaterIds)
+        const theaters = await this.theatersService.getMany(theaterIds, session, signal)
 
         const theatersById = new Map<string, TheaterDto>()
         theaters.forEach((theater) => theatersById.set(theater.id, theater))
 
-        await Promise.all(
-            showtimes.map(async (showtime) => {
-                const theater = theatersById.get(showtime.theaterId)
-
-                Require.defined(theater, 'The theater must exist.')
-
-                const createTicketDtos = Seatmap.getAllSeats(theater.seatmap).map((seat) => ({
-                    movieId: showtime.movieId,
-                    sagaId,
-                    seat,
-                    showtimeId: showtime.id,
-                    status: TicketStatus.Available,
-                    theaterId: showtime.theaterId
-                }))
-
-                const { count } = await this.ticketsService.createMany(createTicketDtos)
-                totalCount += count
-            })
+        const seatCountByTheater = new Map(
+            theaters.map((theater) => [theater.id, Seatmap.getSeatCount(theater.seatmap)])
         )
+        const plannedTicketCount = showtimes.reduce((count, showtime) => {
+            const seatCount = seatCountByTheater.get(showtime.theaterId)
+            Require.defined(seatCount, 'The theater seat count must exist.')
+            return count + seatCount
+        }, 0)
+        if (MAX_TICKETS_PER_OPERATION < plannedTicketCount) {
+            throw new BadRequestException(
+                ShowtimeCreationErrors.TooManyTickets(MAX_TICKETS_PER_OPERATION)
+            )
+        }
 
-        return totalCount
+        const createTicketDtos = showtimes.flatMap((showtime) => {
+            const theater = theatersById.get(showtime.theaterId)
+
+            Require.defined(theater, 'The theater must exist.')
+
+            return Seatmap.getAllSeats(theater.seatmap).map((seat) => ({
+                movieId: showtime.movieId,
+                sagaId,
+                seat,
+                showtimeId: showtime.id,
+                status: TicketStatus.Available,
+                theaterId: showtime.theaterId
+            }))
+        })
+
+        const { count } = await this.ticketsService.createMany(createTicketDtos, session, signal)
+        return count
     }
 }

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-bulk-validator.service.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-bulk-validator.service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose'
 import { DateTimeRange, DateUtil, Require } from '@mannercode/common'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { MoviesService, ShowtimeDto, ShowtimesService, TheatersService } from 'core'
@@ -20,11 +21,15 @@ export class ShowtimeBulkValidatorService {
         private readonly showtimesService: ShowtimesService
     ) {}
 
-    async validate(createDto: BulkCreateShowtimesDto) {
-        await this.verifyMovieExists(createDto.movieId)
-        await this.verifyTheatersExist(createDto.theaterIds)
+    async validate(
+        createDto: BulkCreateShowtimesDto,
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        await this.verifyMovieExists(createDto.movieId, session, signal)
+        await this.verifyTheatersExist(createDto.theaterIds, session, signal)
 
-        const conflictingShowtimes = await this.findConflictingShowtimes(createDto)
+        const conflictingShowtimes = await this.findConflictingShowtimes(createDto, session, signal)
 
         this.logger.log('validate completed', {
             movieId: createDto.movieId,
@@ -35,10 +40,14 @@ export class ShowtimeBulkValidatorService {
         return { conflictingShowtimes, isValid: 0 === conflictingShowtimes.length }
     }
 
-    private async findConflictingShowtimes(createDto: BulkCreateShowtimesDto) {
+    private async findConflictingShowtimes(
+        createDto: BulkCreateShowtimesDto,
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
         const { durationInMinutes, startTimes, theaterIds } = createDto
 
-        const existingByTheater = await this.fetchExistingByTheater(createDto)
+        const existingByTheater = await this.fetchExistingByTheater(createDto, session, signal)
 
         // 한 기존 상영이 여러 새 시작 시각과 겹쳐도 결과에는 한 번만 들어가도록 상영 ID 기준으로 중복을 제거한다.
         const conflictsById = new Map<string, ShowtimeDto>()
@@ -64,7 +73,11 @@ export class ShowtimeBulkValidatorService {
         return [...conflictsById.values()]
     }
 
-    private async fetchExistingByTheater(createDto: BulkCreateShowtimesDto) {
+    private async fetchExistingByTheater(
+        createDto: BulkCreateShowtimesDto,
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
         const { durationInMinutes, startTimes, theaterIds } = createDto
 
         const startDate = DateUtil.earliest(startTimes)
@@ -73,29 +86,44 @@ export class ShowtimeBulkValidatorService {
 
         // 새 상영 범위보다 일찍 시작한 기존 상영도 끝 시각이 범위 안에 들어오면 충돌이다.
         // 예를 들어 새 상영이 10:00-12:00이고 기존 상영이 09:00-11:00이면 11:00까지 시간이 겹친다.
-        const fetched = await Promise.all(
-            theaterIds.map((theaterId) =>
-                this.showtimesService.search({
-                    endTimeRange: { start: startDate },
-                    startTimeRange: { end: endDate },
-                    theaterIds: [theaterId]
-                })
-            )
+        // 한 transaction session에서는 병렬 Mongo 명령을 실행하지 않는다. 극장 전체를 한 번에 조회해 묶는다.
+        const fetched = await this.showtimesService.search(
+            { endTimeRange: { start: startDate }, startTimeRange: { end: endDate }, theaterIds },
+            session,
+            signal
         )
-
-        return new Map(theaterIds.map((theaterId, index) => [theaterId, fetched[index]]))
+        const existingByTheater = new Map<string, ShowtimeDto[]>(
+            theaterIds.map((theaterId) => [theaterId, []])
+        )
+        for (const showtime of fetched) {
+            const existing = existingByTheater.get(showtime.theaterId)
+            Require.defined(
+                existing,
+                `Existing showtimes must be defined for theater ID: ${showtime.theaterId}`
+            )
+            existing.push(showtime)
+        }
+        return existingByTheater
     }
 
-    private async verifyMovieExists(movieId: string) {
-        const movieExists = await this.moviesService.allExist([movieId])
+    private async verifyMovieExists(
+        movieId: string,
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
+        const movieExists = await this.moviesService.allExist([movieId], session, signal)
 
         if (!movieExists) {
             throw new NotFoundException(ShowtimeCreationErrors.MovieNotFound(movieId))
         }
     }
 
-    private async verifyTheatersExist(theaterIds: string[]) {
-        const theatersExist = await this.theatersService.allExist(theaterIds)
+    private async verifyTheatersExist(
+        theaterIds: string[],
+        session: ClientSession | undefined,
+        signal: AbortSignal | undefined
+    ) {
+        const theatersExist = await this.theatersService.allExist(theaterIds, session, signal)
 
         if (!theatersExist) {
             throw new NotFoundException(ShowtimeCreationErrors.TheatersNotFound(theaterIds))

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-creation-operation.repository.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-creation-operation.repository.ts
@@ -1,0 +1,36 @@
+import type { ClientSession, Model } from 'mongoose'
+import { CrudRepository } from '@mannercode/common'
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
+import type { ValidateAndCreateResult } from './types'
+import { ShowtimeCreationOperation } from './models'
+
+@Injectable()
+export class ShowtimeCreationOperationRepository extends CrudRepository<ShowtimeCreationOperation> {
+    constructor(
+        @InjectModel(ShowtimeCreationOperation.name, MONGO_CONNECTION_NAME)
+        readonly model: Model<ShowtimeCreationOperation>,
+        config: AppConfigService
+    ) {
+        super(model, config.http.paginationDefaultSize, config.http.paginationMaxSize)
+    }
+
+    async create(
+        sagaId: string,
+        inputHash: string,
+        result: ValidateAndCreateResult,
+        session: ClientSession,
+        signal: AbortSignal | undefined
+    ) {
+        const operation = this.newDocument()
+        operation.sagaId = sagaId
+        operation.inputHash = inputHash
+        operation.result = result
+        await this.saveMany([operation], session, signal)
+    }
+
+    async findBySagaId(sagaId: string, session: ClientSession, signal: AbortSignal | undefined) {
+        return this.model.findOne({ sagaId }, null, { session, signal }).lean().exec()
+    }
+}

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-creation-orchestrator.service.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-creation-orchestrator.service.ts
@@ -7,8 +7,8 @@ import {
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { TEMPORAL_CLIENT_NAME } from 'config'
 import { BulkCreateShowtimesDto } from '../dtos'
+import { getShowtimeCreationTaskQueue } from '../showtime-creation-task-queue'
 import { ShowtimeCreationEvents } from '../showtime-creation.events'
-import { getShowtimeCreationTaskQueue } from '../worker'
 import { ShowtimeCreationStatus } from './types'
 
 @Injectable()
@@ -27,7 +27,7 @@ export class ShowtimeCreationOrchestratorService {
 
         // `workflowId`를 `sagaId`와 같게 두어 Temporal 실행 기록과 API 응답의 사가 식별자를 연결한다.
         // 같은 ID로 두 번 시작하려는 요청은 `REJECT_DUPLICATE` 옵션이 막으므로 별도 중복 방지 키가 필요 없다.
-        await this.temporal.workflow.start('showtimeCreationWorkflow', {
+        await this.temporal.workflow.start('showtimeCreationWorkflowV2', {
             args: [{ createDto, sagaId }],
             taskQueue: getShowtimeCreationTaskQueue(),
             workflowId: sagaId,

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-creation-persistence.service.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-creation-persistence.service.ts
@@ -1,0 +1,100 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { TheatersService } from 'core'
+import { createHash } from 'crypto'
+import type { BulkCreateShowtimesDto } from '../dtos'
+import type { ValidateAndCreateResult } from './types'
+import { ShowtimeCreationErrors } from '../errors'
+import { ShowtimeBulkCreatorService } from './showtime-bulk-creator.service'
+import { ShowtimeBulkValidatorService } from './showtime-bulk-validator.service'
+import { ShowtimeCreationOperationRepository } from './showtime-creation-operation.repository'
+
+const COMMIT_TIMEOUT_MS = 10_000
+// MongoDB 드라이버의 transaction callback 재시도까지 Activity 한 시도 안에서 끝낸다.
+// `maxCommitTimeMS`는 개별 commit 명령만 제한하므로 전체 transaction에는 별도 제한이 필요하다.
+const TRANSACTION_TIMEOUT_MS = 45_000
+const MAX_SHOWTIMES_PER_OPERATION = 200
+
+@Injectable()
+export class ShowtimeCreationPersistenceService {
+    constructor(
+        private readonly operations: ShowtimeCreationOperationRepository,
+        private readonly theatersService: TheatersService,
+        private readonly validatorService: ShowtimeBulkValidatorService,
+        private readonly creatorService: ShowtimeBulkCreatorService
+    ) {}
+
+    async validateAndCreate(
+        createDto: BulkCreateShowtimesDto,
+        sagaId: string,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<ValidateAndCreateResult> {
+        const requestedShowtimeCount = createDto.theaterIds.length * createDto.startTimes.length
+        if (MAX_SHOWTIMES_PER_OPERATION < requestedShowtimeCount) {
+            throw new BadRequestException(
+                ShowtimeCreationErrors.TooManyShowtimes(MAX_SHOWTIMES_PER_OPERATION)
+            )
+        }
+
+        const inputHash = this.hashInput(createDto)
+
+        return this.operations.withTransaction(
+            async (session) => {
+                const completed = await this.operations.findBySagaId(sagaId, session, signal)
+                if (completed) {
+                    this.assertSameInput(sagaId, inputHash, completed.inputHash)
+                    return completed.result
+                }
+
+                // 이 쓰기를 검증 조회보다 먼저 실행해야 같은 극장의 concurrent transaction이
+                // 서로 다른 snapshot에서 둘 다 검증을 통과하지 않고 WriteConflict로 직렬화된다.
+                const guardsAcquired = await this.theatersService.acquireShowtimeScheduleGuards(
+                    createDto.theaterIds,
+                    session,
+                    signal
+                )
+                if (!guardsAcquired) {
+                    throw new NotFoundException(
+                        ShowtimeCreationErrors.TheatersNotFound(createDto.theaterIds)
+                    )
+                }
+
+                const { conflictingShowtimes, isValid } = await this.validatorService.validate(
+                    createDto,
+                    session,
+                    signal
+                )
+                const result: ValidateAndCreateResult = isValid
+                    ? {
+                          kind: 'succeeded',
+                          ...(await this.creatorService.create(createDto, sagaId, session, signal))
+                      }
+                    : { conflictingShowtimes, kind: 'failed' }
+
+                await this.operations.create(sagaId, inputHash, result, session, signal)
+                return result
+            },
+            {
+                maxCommitTimeMS: COMMIT_TIMEOUT_MS,
+                readConcern: { level: 'snapshot' },
+                timeoutMS: TRANSACTION_TIMEOUT_MS,
+                writeConcern: { w: 'majority' }
+            }
+        )
+    }
+
+    private assertSameInput(sagaId: string, expectedHash: string, actualHash: string) {
+        if (expectedHash !== actualHash) {
+            throw new Error(`Saga ID was reused with different input (sagaId=${sagaId})`)
+        }
+    }
+
+    private hashInput(createDto: BulkCreateShowtimesDto) {
+        const normalized = {
+            durationInMinutes: createDto.durationInMinutes,
+            movieId: createDto.movieId,
+            startTimes: createDto.startTimes.map((date) => date.toISOString()).sort(),
+            theaterIds: [...createDto.theaterIds].sort()
+        }
+        return createHash('sha256').update(JSON.stringify(normalized)).digest('hex')
+    }
+}

--- a/apps/api/src/services/application/showtime-creation/internal/types.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/types.ts
@@ -26,3 +26,7 @@ export type ShowtimeCreationEvent =
           createdTicketCount: number
       }
     | { sagaId: string; status: typeof ShowtimeCreationStatus.Waiting }
+
+export type ValidateAndCreateResult =
+    | { kind: 'failed'; conflictingShowtimes: ShowtimeDto[] }
+    | { kind: 'succeeded'; createdShowtimeCount: number; createdTicketCount: number }

--- a/apps/api/src/services/application/showtime-creation/showtime-creation-task-queue.ts
+++ b/apps/api/src/services/application/showtime-creation/showtime-creation-task-queue.ts
@@ -1,0 +1,13 @@
+import { getProjectId } from 'config'
+
+/**
+ * 작업 큐 이름에 PROJECT_ID를 포함해 병렬 테스트 워커의 실행 공간을 분리한다.
+ * 운영에서는 PROJECT_ID가 고정되어 큐 이름도 안정적으로 유지된다.
+ */
+export function getLegacyShowtimeCreationTaskQueue() {
+    return `showtime-creation-${getProjectId()}`
+}
+
+export function getShowtimeCreationTaskQueue() {
+    return `showtime-creation-v2-${getProjectId()}`
+}

--- a/apps/api/src/services/application/showtime-creation/showtime-creation.module.ts
+++ b/apps/api/src/services/application/showtime-creation/showtime-creation.module.ts
@@ -1,27 +1,50 @@
 import { CacheModule, NatsPubSubModule, TemporalWorkerService } from '@mannercode/common'
 import { Module } from '@nestjs/common'
-import { AppConfigService, getProjectId, NATS_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
+import { MongooseModule } from '@nestjs/mongoose'
+import {
+    AppConfigService,
+    getProjectId,
+    MONGO_CONNECTION_NAME,
+    NATS_CONNECTION_NAME,
+    REDIS_CONNECTION_NAME
+} from 'config'
 import { MoviesModule, ShowtimesModule, TheatersModule, TicketsModule } from 'core'
 import {
     ShowtimeBulkCreatorService,
     ShowtimeBulkValidatorService,
-    ShowtimeCreationOrchestratorService
+    ShowtimeCreationOrchestratorService,
+    ShowtimeCreationPersistenceService
 } from './internal'
+import { ShowtimeCreationOperation, ShowtimeCreationOperationSchema } from './internal/models'
+import { ShowtimeCreationOperationRepository } from './internal/showtime-creation-operation.repository'
+import {
+    getLegacyShowtimeCreationTaskQueue,
+    getShowtimeCreationTaskQueue
+} from './showtime-creation-task-queue'
 import { ShowtimeCreationEvents } from './showtime-creation.events'
 import { ShowtimeCreationService } from './showtime-creation.service'
 import { ShowtimeCreationActivities } from './worker/activities'
-import { showtimeCreationBundle } from './worker/bundle'
-import { getShowtimeCreationTaskQueue } from './worker/types'
+import { legacyShowtimeCreationBundle, showtimeCreationBundle } from './worker/bundle'
+import { LegacyShowtimeCreationActivities } from './worker/legacy-activities'
+
+const LEGACY_SHOWTIME_CREATION_WORKER = Symbol('LEGACY_SHOWTIME_CREATION_WORKER')
+const SHOWTIME_CREATION_WORKER = Symbol('SHOWTIME_CREATION_WORKER')
 
 @Module({
     exports: [ShowtimeCreationService, ShowtimeCreationEvents],
     imports: [
         NatsPubSubModule.register({ natsName: NATS_CONNECTION_NAME }),
+        // v2도 rolling migration 동안 v1 binary와 같은 lock key를 사용한다.
+        // original Temporal queue가 완전히 drain된 뒤 별도 릴리스에서 제거할 수 있다.
         CacheModule.register({
             name: 'showtime-creation',
             prefix: `cache:${getProjectId()}`,
             redisName: REDIS_CONNECTION_NAME
         }),
+        MongooseModule.forFeature(
+            [{ name: ShowtimeCreationOperation.name, schema: ShowtimeCreationOperationSchema }],
+            MONGO_CONNECTION_NAME
+        ),
         MoviesModule,
         TheatersModule,
         ShowtimesModule,
@@ -33,12 +56,33 @@ import { getShowtimeCreationTaskQueue } from './worker/types'
         ShowtimeCreationOrchestratorService,
         ShowtimeBulkValidatorService,
         ShowtimeBulkCreatorService,
+        ShowtimeCreationOperationRepository,
+        ShowtimeCreationPersistenceService,
+        LegacyShowtimeCreationActivities,
         ShowtimeCreationActivities,
         // 워커 제공자를 이 모듈에 직접 두어 `ShowtimeCreationActivities`를 같은 제공자 범위에서 주입받는다.
         // 별도 자식 모듈로 감싸면 factory가 이 모듈의 제공자를 볼 수 없다.
         {
+            inject: [AppConfigService, LegacyShowtimeCreationActivities],
+            provide: LEGACY_SHOWTIME_CREATION_WORKER,
+            useFactory: (config: AppConfigService, activities: LegacyShowtimeCreationActivities) =>
+                new TemporalWorkerService({
+                    activities: activities.bind(),
+                    address: config.temporal.address,
+                    // poller 수만 낮춘다. 실행 slot은 넉넉히 유지해야 오래 잠긴 v1 validate 작업이
+                    // compensate/상태 발행 Activity를 굶기지 않는다.
+                    maxConcurrentActivityTaskExecutions: 100,
+                    maxConcurrentActivityTaskPolls: 1,
+                    maxConcurrentWorkflowTaskExecutions: 2,
+                    maxConcurrentWorkflowTaskPolls: 2,
+                    namespace: config.temporal.namespace,
+                    taskQueue: getLegacyShowtimeCreationTaskQueue(),
+                    workflowBundlePath: legacyShowtimeCreationBundle.bundlePath
+                })
+        },
+        {
             inject: [AppConfigService, ShowtimeCreationActivities],
-            provide: TemporalWorkerService,
+            provide: SHOWTIME_CREATION_WORKER,
             useFactory: (config: AppConfigService, activities: ShowtimeCreationActivities) =>
                 new TemporalWorkerService({
                     activities: activities.bind(),

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/legacy-activities.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/legacy-activities.spec.ts
@@ -1,0 +1,109 @@
+import type { ShowtimesService, TicketsService } from 'core'
+import { newObjectIdString, type CacheService } from '@mannercode/common'
+import { nullObjectId } from '@mannercode/testing'
+import type {
+    ShowtimeBulkCreatorService,
+    ShowtimeBulkValidatorService,
+    ShowtimeCreationEvent
+} from '../../internal'
+import type { ShowtimeCreationEvents } from '../../showtime-creation.events'
+import type { LegacyShowtimeCreationWorkflowInput } from '../legacy-types'
+import { LegacyShowtimeCreationActivities } from '../legacy-activities'
+
+describe('LegacyShowtimeCreationActivities', () => {
+    let activities: LegacyShowtimeCreationActivities
+    let emitStatusChanged: jest.Mock
+    let validate: jest.Mock
+    let create: jest.Mock
+    let deleteShowtimes: jest.Mock
+    let deleteTickets: jest.Mock
+
+    const input = (): LegacyShowtimeCreationWorkflowInput => ({
+        createDto: {
+            durationInMinutes: 1,
+            movieId: nullObjectId,
+            startTimes: [new Date('2100-01-01T09:00:00.000Z')],
+            theaterIds: [nullObjectId]
+        },
+        sagaId: newObjectIdString()
+    })
+
+    beforeEach(() => {
+        emitStatusChanged = jest.fn(async () => undefined)
+        validate = jest.fn(async () => ({ conflictingShowtimes: [], isValid: true }))
+        create = jest.fn(async () => ({ createdShowtimeCount: 1, createdTicketCount: 10 }))
+        deleteShowtimes = jest.fn(async () => undefined)
+        deleteTickets = jest.fn(async () => undefined)
+
+        const cache = {
+            withLockBlocking: jest.fn(async (_key: string, _ttlMs: number, fn: () => unknown) =>
+                fn()
+            )
+        } as unknown as CacheService
+
+        activities = new LegacyShowtimeCreationActivities(
+            { emitStatusChanged } as unknown as ShowtimeCreationEvents,
+            { validate } as unknown as ShowtimeBulkValidatorService,
+            { create } as unknown as ShowtimeBulkCreatorService,
+            { deleteBySagaIds: deleteShowtimes } as unknown as ShowtimesService,
+            { deleteBySagaIds: deleteTickets } as unknown as TicketsService,
+            cache
+        )
+    })
+
+    it('bind한 상태 발행 Activity가 이벤트 서비스에 위임한다', async () => {
+        const event: ShowtimeCreationEvent = { sagaId: newObjectIdString(), status: 'processing' }
+
+        await activities.bind().emitStatusChanged(event)
+
+        expect(emitStatusChanged).toHaveBeenCalledWith(event)
+    })
+
+    it('검증을 통과하면 v1 생성 결과를 반환한다', async () => {
+        const workflowInput = input()
+
+        await expect(activities.bind().validateAndCreate(workflowInput)).resolves.toEqual({
+            createdShowtimeCount: 1,
+            createdTicketCount: 10,
+            kind: 'succeeded'
+        })
+        expect(validate).toHaveBeenCalledWith(workflowInput.createDto)
+        expect(create).toHaveBeenCalledWith(workflowInput.createDto, workflowInput.sagaId)
+    })
+
+    it('충돌하면 생성하지 않고 v1 실패 결과를 반환한다', async () => {
+        const conflict = {
+            endTime: new Date('2100-01-01T10:00:00.000Z'),
+            id: newObjectIdString(),
+            movieId: nullObjectId,
+            startTime: new Date('2100-01-01T09:00:00.000Z'),
+            theaterId: nullObjectId
+        }
+        validate.mockResolvedValue({ conflictingShowtimes: [conflict], isValid: false })
+
+        await expect(activities.validateAndCreate(input())).resolves.toEqual({
+            conflictingShowtimes: [conflict],
+            kind: 'failed'
+        })
+        expect(create).not.toHaveBeenCalled()
+    })
+
+    it('v1 보상은 tickets와 showtimes를 모두 삭제한다', async () => {
+        const sagaId = newObjectIdString()
+
+        await activities.bind().compensate(sagaId)
+
+        expect(deleteTickets).toHaveBeenCalledWith([sagaId])
+        expect(deleteShowtimes).toHaveBeenCalledWith([sagaId])
+    })
+
+    it('v1 보상 중 한 삭제가 실패해도 다른 삭제를 시도한 뒤 원인을 던진다', async () => {
+        const sagaId = newObjectIdString()
+        deleteShowtimes.mockRejectedValue(new Error('showtime cleanup failed'))
+
+        await expect(activities.compensate(sagaId)).rejects.toThrow(
+            `compensate failed (sagaId=${sagaId}): showtimes=showtime cleanup failed`
+        )
+        expect(deleteTickets).toHaveBeenCalledWith([sagaId])
+    })
+})

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/legacy-workflow.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/legacy-workflow.spec.ts
@@ -1,0 +1,119 @@
+import { newObjectIdString } from '@mannercode/common'
+import { nullObjectId, withTestId } from '@mannercode/testing'
+import { Client, Connection } from '@temporalio/client'
+import { NativeConnection, Worker } from '@temporalio/worker'
+import { readFileSync } from 'fs'
+import type { ShowtimeCreationEvent, ValidateAndCreateResult } from '../../internal'
+import type { LegacyShowtimeCreationWorkflowInput } from '../legacy-types'
+import { legacyShowtimeCreationBundle } from '../bundle'
+
+type LegacyWorkflowActivities = {
+    compensate: (sagaId: string) => Promise<void>
+    emitStatusChanged: (payload: ShowtimeCreationEvent) => Promise<void>
+    validateAndCreate: (
+        input: LegacyShowtimeCreationWorkflowInput
+    ) => Promise<ValidateAndCreateResult>
+}
+
+const address = `${process.env.TEMPORAL_HOST}:${process.env.TEMPORAL_PORT}`
+const namespace = process.env.TEMPORAL_NAMESPACE as string
+
+describe('legacy showtimeCreationWorkflow', () => {
+    let connection: Connection
+    let nativeConnection: NativeConnection
+    let client: Client
+    let bundleCode: string
+
+    beforeAll(async () => {
+        connection = await Connection.connect({ address })
+        nativeConnection = await NativeConnection.connect({ address })
+        client = new Client({ connection, namespace })
+        bundleCode = readFileSync(legacyShowtimeCreationBundle.bundlePath, 'utf8')
+    }, 60_000)
+
+    afterAll(async () => {
+        await connection.close()
+        await nativeConnection.close()
+    })
+
+    const buildInput = (): LegacyShowtimeCreationWorkflowInput => ({
+        createDto: {
+            durationInMinutes: 1,
+            movieId: nullObjectId,
+            startTimes: [new Date('2100-01-01T09:00:00.000Z')],
+            theaterIds: [nullObjectId]
+        },
+        sagaId: newObjectIdString()
+    })
+
+    async function runWorkflow(
+        input: LegacyShowtimeCreationWorkflowInput,
+        activities: LegacyWorkflowActivities
+    ) {
+        const taskQueue = withTestId('showtime-creation-v1-unit')
+        const worker = await Worker.create({
+            activities,
+            connection: nativeConnection,
+            namespace,
+            taskQueue,
+            workflowBundle: { code: bundleCode }
+        })
+
+        await worker.runUntil(
+            client.workflow.execute('showtimeCreationWorkflow', {
+                args: [input],
+                taskQueue,
+                workflowId: withTestId('showtime-creation-v1-wf')
+            })
+        )
+    }
+
+    it('기존 성공 command 순서를 보존한다', async () => {
+        const timeline: string[] = []
+        const input = buildInput()
+        const activities: LegacyWorkflowActivities = {
+            compensate: jest.fn(async () => {
+                timeline.push('compensate')
+            }),
+            emitStatusChanged: jest.fn(async ({ status }) => {
+                timeline.push(`emit:${status}`)
+            }),
+            validateAndCreate: jest.fn(async (): Promise<ValidateAndCreateResult> => {
+                timeline.push('validateAndCreate')
+                return { createdShowtimeCount: 1, createdTicketCount: 10, kind: 'succeeded' }
+            })
+        }
+
+        await runWorkflow(input, activities)
+
+        expect(timeline).toEqual(['emit:processing', 'validateAndCreate', 'emit:succeeded'])
+        expect(activities.compensate).not.toHaveBeenCalled()
+    })
+
+    it('기존 실패 history처럼 보상 뒤 error를 발행한다', async () => {
+        const timeline: string[] = []
+        const input = buildInput()
+        const activities: LegacyWorkflowActivities = {
+            compensate: jest.fn(async () => {
+                timeline.push('compensate')
+            }),
+            emitStatusChanged: jest.fn(async ({ status }) => {
+                timeline.push(`emit:${status}`)
+            }),
+            validateAndCreate: jest.fn(async () => {
+                timeline.push('validateAndCreate')
+                throw new Error('legacy create failed')
+            })
+        }
+
+        await runWorkflow(input, activities)
+
+        expect(timeline).toEqual([
+            'emit:processing',
+            'validateAndCreate',
+            'compensate',
+            'emit:error'
+        ])
+        expect(activities.compensate).toHaveBeenCalledWith(input.sagaId)
+    })
+})

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/workflow.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/workflow.spec.ts
@@ -11,7 +11,6 @@ import { showtimeCreationBundle } from '../bundle'
 
 // 샌드박스 워크플로는 Istanbul이 계측할 수 없어 실제 Temporal 워커에 mock 액티비티를 주입한다.
 type WorkflowActivities = {
-    compensate: (sagaId: string) => Promise<void>
     emitStatusChanged: (payload: ShowtimeCreationEvent) => Promise<void>
     validateAndCreate: (input: ShowtimeCreationWorkflowInput) => Promise<ValidateAndCreateResult>
 }
@@ -19,7 +18,7 @@ type WorkflowActivities = {
 const address = `${process.env.TEMPORAL_HOST}:${process.env.TEMPORAL_PORT}`
 const namespace = process.env.TEMPORAL_NAMESPACE as string
 
-describe('showtimeCreationWorkflow', () => {
+describe('showtimeCreationWorkflowV2', () => {
     let connection: Connection
     let nativeConnection: NativeConnection
     let client: Client
@@ -51,7 +50,7 @@ describe('showtimeCreationWorkflow', () => {
         })
 
         await worker.runUntil(
-            client.workflow.execute('showtimeCreationWorkflow', {
+            client.workflow.execute('showtimeCreationWorkflowV2', {
                 args: [input],
                 taskQueue,
                 workflowId: withTestId('showtime-creation-wf')
@@ -78,16 +77,14 @@ describe('showtimeCreationWorkflow', () => {
             createdTicketCount: 30,
             kind: 'succeeded'
         }))
-        const compensate = jest.fn(async () => {})
         const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
             statuses.push(payload)
         })
 
         const input = buildInput()
-        await runWorkflow(input, { compensate, emitStatusChanged, validateAndCreate })
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
 
         expect(validateAndCreate).toHaveBeenCalledTimes(1)
-        expect(compensate).not.toHaveBeenCalled()
         expect(statuses.map((s) => s.status)).toEqual(['processing', 'succeeded'])
 
         const succeeded = statuses[1]
@@ -114,15 +111,13 @@ describe('showtimeCreationWorkflow', () => {
             conflictingShowtimes: conflicting,
             kind: 'failed'
         }))
-        const compensate = jest.fn(async () => {})
         const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
             statuses.push(payload)
         })
 
         const input = buildInput()
-        await runWorkflow(input, { compensate, emitStatusChanged, validateAndCreate })
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
 
-        expect(compensate).not.toHaveBeenCalled()
         expect(statuses.map((s) => s.status)).toEqual(['processing', 'failed'])
 
         const failed = statuses[1]
@@ -133,27 +128,21 @@ describe('showtimeCreationWorkflow', () => {
         }
     })
 
-    it('validateAndCreate가 실패하면 보상한 뒤 오류 상태를 알린다', async () => {
-        // 보상이 오류 알림보다 먼저 일어나야 한다.
-        // 알림이 먼저 나가면 클라이언트가 정리 완료로 오인할 수 있다.
+    it('validateAndCreate가 재시도를 소진하면 오류 상태를 알린다', async () => {
         const timeline: string[] = []
         const validateAndCreate = jest.fn(async (): Promise<ValidateAndCreateResult> => {
             throw new Error('boom during create')
-        })
-        const compensate = jest.fn(async () => {
-            timeline.push('compensate')
         })
         const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
             timeline.push(`emit:${payload.status}`)
         })
 
         const input = buildInput()
-        await runWorkflow(input, { compensate, emitStatusChanged, validateAndCreate })
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
 
-        // 검증·생성은 자동 재시도를 끄므로 한 번만 실행되어야 한다(재시도 시 중복 생성 위험).
-        expect(validateAndCreate).toHaveBeenCalledTimes(1)
-        expect(compensate).toHaveBeenCalledWith(input.sagaId)
-        expect(timeline).toEqual(['emit:processing', 'compensate', 'emit:error'])
+        // 검증·생성은 sagaId로 멱등이므로 일시 장애를 위해 정해진 횟수만 재시도한다.
+        expect(validateAndCreate).toHaveBeenCalledTimes(4)
+        expect(timeline).toEqual(['emit:processing', 'emit:error'])
 
         const errorEvent = emitStatusChanged.mock.calls
             .map((call) => call[0])
@@ -165,26 +154,80 @@ describe('showtimeCreationWorkflow', () => {
         }
     })
 
-    it('보상이 재시도를 소진하면 error 이벤트 없이 워크플로 실패로 남는다', async () => {
-        // error 이벤트는 '보상까지 완료됨'을 뜻하므로, 보상이 못 끝났으면 발행하지 않고 워크플로 실패로 드러나야 한다.
+    it('validateAndCreate가 일시적으로 실패해도 재시도해 성공한다', async () => {
         const statuses: ShowtimeCreationEvent[] = []
-        const validateAndCreate = jest.fn(async (): Promise<ValidateAndCreateResult> => {
-            throw new Error('boom during create')
+        const validateAndCreate = jest
+            .fn(async (): Promise<ValidateAndCreateResult> => ({
+                createdShowtimeCount: 1,
+                createdTicketCount: 10,
+                kind: 'succeeded'
+            }))
+            .mockRejectedValueOnce(new Error('stale compatibility lock'))
+            .mockRejectedValueOnce(new Error('stale compatibility lock'))
+            .mockRejectedValueOnce(new Error('stale compatibility lock'))
+        const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
+            statuses.push(payload)
         })
-        const compensate = jest.fn(async () => {
-            throw new Error('compensation keeps failing')
+
+        const input = buildInput()
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
+
+        expect(validateAndCreate).toHaveBeenCalledTimes(4)
+        expect(statuses.map((status) => status.status)).toEqual(['processing', 'succeeded'])
+    })
+
+    it('시작된 시도가 heartbeat 없이 멈춰도 timeout 뒤 다음 시도로 회복한다', async () => {
+        const statuses: ShowtimeCreationEvent[] = []
+        const succeeded: ValidateAndCreateResult = {
+            createdShowtimeCount: 1,
+            createdTicketCount: 10,
+            kind: 'succeeded'
+        }
+        let releaseFirst: (() => void) | undefined
+        const validateAndCreate = jest.fn(async (): Promise<ValidateAndCreateResult> => {
+            if (validateAndCreate.mock.calls.length === 1) {
+                return new Promise<ValidateAndCreateResult>((resolve) => {
+                    releaseFirst = () => resolve(succeeded)
+                })
+            }
+
+            // timeout된 첫 handler도 종료시켜 Worker가 drain될 수 있게 한다. 늦은 완료 보고는 Temporal이 무시한다.
+            releaseFirst?.()
+            return succeeded
         })
         const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
             statuses.push(payload)
         })
 
         const input = buildInput()
-        await expect(
-            runWorkflow(input, { compensate, emitStatusChanged, validateAndCreate })
-        ).rejects.toThrow(WorkflowFailedError)
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
 
-        // 보상은 재시도 상한(maximumAttempts: 3)까지만 시도되어야 한다 — 무제한이면 워크플로가 영원히 매달린다.
-        expect(compensate).toHaveBeenCalledTimes(3)
+        expect(validateAndCreate).toHaveBeenCalledTimes(2)
+        expect(statuses.map((status) => status.status)).toEqual(['processing', 'succeeded'])
+    }, 45_000)
+
+    it('성공 상태 발행이 재시도를 소진하면 error로 바꾸지 않고 워크플로 실패로 남긴다', async () => {
+        const statuses: ShowtimeCreationEvent[] = []
+        const validateAndCreate = jest.fn(async (): Promise<ValidateAndCreateResult> => ({
+            createdShowtimeCount: 1,
+            createdTicketCount: 1,
+            kind: 'succeeded'
+        }))
+        const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
+            if (payload.status === 'succeeded') {
+                throw new Error('terminal publish keeps failing')
+            }
+            statuses.push(payload)
+        })
+
+        const input = buildInput()
+        await expect(runWorkflow(input, { emitStatusChanged, validateAndCreate })).rejects.toThrow(
+            WorkflowFailedError
+        )
+
+        expect(
+            emitStatusChanged.mock.calls.filter(([payload]) => payload.status === 'succeeded')
+        ).toHaveLength(3)
         expect(statuses.map((s) => s.status)).toEqual(['processing'])
     })
 
@@ -197,7 +240,6 @@ describe('showtimeCreationWorkflow', () => {
             createdTicketCount: 1,
             kind: 'succeeded'
         }))
-        const compensate = jest.fn(async () => {})
         const emitStatusChanged = jest.fn(async (payload: ShowtimeCreationEvent) => {
             if (payload.status === 'processing') {
                 processingAttempts++
@@ -209,10 +251,9 @@ describe('showtimeCreationWorkflow', () => {
         })
 
         const input = buildInput()
-        await runWorkflow(input, { compensate, emitStatusChanged, validateAndCreate })
+        await runWorkflow(input, { emitStatusChanged, validateAndCreate })
 
         expect(processingAttempts).toBeGreaterThanOrEqual(2)
         expect(recorded).toEqual(['processing', 'succeeded'])
-        expect(compensate).not.toHaveBeenCalled()
     })
 })

--- a/apps/api/src/services/application/showtime-creation/worker/activities.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/activities.ts
@@ -1,22 +1,24 @@
-import { CacheService, getByPath, InjectCache, JsonUtil } from '@mannercode/common'
+import { CacheService, InjectCache, JsonUtil } from '@mannercode/common'
 import { Injectable, Logger } from '@nestjs/common'
-import { ShowtimeDto, ShowtimesService, TicketsService } from 'core'
+import { Context, heartbeat } from '@temporalio/activity'
 import {
-    ShowtimeBulkCreatorService,
-    ShowtimeBulkValidatorService,
-    ShowtimeCreationEvent
+    ShowtimeCreationPersistenceService,
+    type ShowtimeCreationEvent,
+    type ValidateAndCreateResult
 } from '../internal'
 import { ShowtimeCreationEvents } from '../showtime-creation.events'
+import { LEGACY_VALIDATE_CREATE_LOCK_KEY } from './legacy-lock'
 import { ShowtimeCreationWorkflowInput } from './types'
 
-export type ValidateAndCreateResult =
-    | { kind: 'failed'; conflictingShowtimes: ShowtimeDto[] }
-    | { kind: 'succeeded'; createdShowtimeCount: number; createdTicketCount: number }
+export type { ValidateAndCreateResult } from '../internal'
 
-const VALIDATE_CREATE_LOCK_KEY = 'validate-and-create'
-// 액티비티 제한과 같게 두어 정상 실행 중에는 락이 먼저 풀리지 않게 한다.
-const VALIDATE_CREATE_LOCK_TTL_MS = 15 * 60 * 1000
-const VALIDATE_CREATE_LOCK_WAIT_MS = 10 * 60 * 1000
+const HEARTBEAT_INTERVAL_MS = 5_000
+// v1 binary가 잡을 수 있는 legacy lock과 교차 직렬화하는 rolling-migration fence다.
+// transaction 자체는 45초 안에 끝나므로 TTL이 먼저 만료되지 않게 여유를 둔다.
+// old v1이 이미 15분 lock을 보유한 전환 구간에는 5분 SSE 상한을 넘겨 기다리지 않고 재시도 후 error로 끝난다.
+// 무중단 가용성까지 필요하면 신규 enqueue 전에 v1 workflow/worker drain을 운영 절차로 보장해야 한다.
+const COMPATIBILITY_LOCK_TTL_MS = 55_000
+const COMPATIBILITY_LOCK_WAIT_MS = 8_000
 
 @Injectable()
 export class ShowtimeCreationActivities {
@@ -24,17 +26,13 @@ export class ShowtimeCreationActivities {
 
     constructor(
         private readonly events: ShowtimeCreationEvents,
-        private readonly validatorService: ShowtimeBulkValidatorService,
-        private readonly creatorService: ShowtimeBulkCreatorService,
-        private readonly showtimesService: ShowtimesService,
-        private readonly ticketsService: TicketsService,
+        private readonly persistence: ShowtimeCreationPersistenceService,
         @InjectCache('showtime-creation') private readonly cache: CacheService
     ) {}
 
     // Temporal은 일반 함수로 호출하므로 인스턴스 컨텍스트를 고정한다.
     bind() {
         return {
-            compensate: this.compensate.bind(this),
             emitStatusChanged: this.emitStatusChanged.bind(this),
             validateAndCreate: this.validateAndCreate.bind(this)
         }
@@ -48,59 +46,32 @@ export class ShowtimeCreationActivities {
         input: ShowtimeCreationWorkflowInput
     ): Promise<ValidateAndCreateResult> {
         const { createDto, sagaId } = JsonUtil.reviveDates(input)
+        const context = Context.current()
 
-        // 검증과 삽입은 복제본 경계를 넘어 원자적으로 취급해야 한다.
-        // 두 워커가 같은 시간대의 사가를 동시에 검증하면, 아직 삽입되지 않은 서로의 결과를 보지 못해 둘 다 통과할 수 있다.
-        // 분산 락 안에서 검증과 삽입을 함께 실행해 같은 시간대는 한 사가씩 처리한다.
-        return this.cache.withLockBlocking<ValidateAndCreateResult>(
-            VALIDATE_CREATE_LOCK_KEY,
-            VALIDATE_CREATE_LOCK_TTL_MS,
-            async () => {
-                const { conflictingShowtimes, isValid } =
-                    await this.validatorService.validate(createDto)
-
-                if (isValid) {
-                    const creationResult = await this.creatorService.create(createDto, sagaId)
-                    return { kind: 'succeeded', ...creationResult }
-                }
-                return { conflictingShowtimes, kind: 'failed' }
-            },
-            { waitMs: VALIDATE_CREATE_LOCK_WAIT_MS }
+        heartbeat({ phase: 'started', sagaId })
+        const timer = setInterval(
+            () => heartbeat({ phase: 'transaction', sagaId }),
+            HEARTBEAT_INTERVAL_MS
         )
-    }
+        timer.unref()
 
-    async compensate(sagaId: string): Promise<void> {
-        // 타임아웃으로 버려진 `validateAndCreate`가 아직 락 안에서 삽입 중일 수 있다.
-        // 같은 락을 기다렸다가 정리해, 좀비 실행과 경합해 고아 행이 남는 일을 막는다.
-        await this.cache.withLockBlocking(
-            VALIDATE_CREATE_LOCK_KEY,
-            VALIDATE_CREATE_LOCK_TTL_MS,
-            async () => {
-                const targets = ['tickets', 'showtimes'] as const
-                const results = await Promise.allSettled([
-                    this.ticketsService.deleteBySagaIds([sagaId]),
-                    this.showtimesService.deleteBySagaIds([sagaId])
-                ])
-
-                // 한쪽이 실패해도 다른 쪽 삭제는 이미 시도된 상태다.
-                // 실패를 던져 Temporal 재시도 정책이 동작하게 한다. 삭제는 멱등이라 전체 재실행이 안전하다.
-                const failures = results
-                    .map((result, i) => ({ result, target: targets[i] }))
-                    .filter(({ result }) => result.status === 'rejected')
-
-                if (0 < failures.length) {
-                    const reasons = failures
-                        .map(
-                            ({ result, target }) =>
-                                `${target}=${getByPath(result, 'reason.message', 'unknown')}`
-                        )
-                        .join(', ')
-                    throw new Error(`compensate failed (sagaId=${sagaId}): ${reasons}`)
-                }
-
-                this.logger.log('compensate completed', { sagaId })
-            },
-            { waitMs: VALIDATE_CREATE_LOCK_WAIT_MS }
-        )
+        try {
+            const result = await this.cache.withLockBlocking(
+                LEGACY_VALIDATE_CREATE_LOCK_KEY,
+                COMPATIBILITY_LOCK_TTL_MS,
+                () =>
+                    this.persistence.validateAndCreate(
+                        createDto,
+                        sagaId,
+                        context.cancellationSignal
+                    ),
+                { signal: context.cancellationSignal, waitMs: COMPATIBILITY_LOCK_WAIT_MS }
+            )
+            heartbeat({ phase: 'committed', sagaId })
+            this.logger.log('validateAndCreate completed', { kind: result.kind, sagaId })
+            return result
+        } finally {
+            clearInterval(timer)
+        }
     }
 }

--- a/apps/api/src/services/application/showtime-creation/worker/bundle.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/bundle.ts
@@ -1,6 +1,11 @@
 import path from 'path'
 
 export const showtimeCreationBundle = {
+    sourcePath: path.resolve(__dirname, 'workflow-v2.ts'),
+    bundlePath: path.resolve(process.cwd(), '_output/workflows/showtime-creation/v2/workflow.js')
+}
+
+export const legacyShowtimeCreationBundle = {
     sourcePath: path.resolve(__dirname, 'workflow.ts'),
-    bundlePath: path.resolve(process.cwd(), '_output/workflows/showtime-creation/workflow.js')
+    bundlePath: path.resolve(process.cwd(), '_output/workflows/showtime-creation/v1/workflow.js')
 }

--- a/apps/api/src/services/application/showtime-creation/worker/legacy-activities.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/legacy-activities.ts
@@ -1,0 +1,98 @@
+import { CacheService, getByPath, InjectCache, JsonUtil } from '@mannercode/common'
+import { Injectable, Logger } from '@nestjs/common'
+import { ShowtimesService, TicketsService } from 'core'
+import {
+    ShowtimeBulkCreatorService,
+    ShowtimeBulkValidatorService,
+    type ShowtimeCreationEvent,
+    type ValidateAndCreateResult
+} from '../internal'
+import { ShowtimeCreationEvents } from '../showtime-creation.events'
+import {
+    LEGACY_VALIDATE_CREATE_LOCK_KEY,
+    LEGACY_VALIDATE_CREATE_LOCK_TTL_MS,
+    LEGACY_VALIDATE_CREATE_LOCK_WAIT_MS
+} from './legacy-lock'
+import { LegacyShowtimeCreationWorkflowInput } from './legacy-types'
+
+/**
+ * 배포 전부터 실행 중인 v1 workflow 전용 Activity다.
+ * original queue가 drain될 때까지 activity 이름과 동작을 보존한다.
+ */
+@Injectable()
+export class LegacyShowtimeCreationActivities {
+    private readonly logger = new Logger(LegacyShowtimeCreationActivities.name)
+
+    constructor(
+        private readonly events: ShowtimeCreationEvents,
+        private readonly validatorService: ShowtimeBulkValidatorService,
+        private readonly creatorService: ShowtimeBulkCreatorService,
+        private readonly showtimesService: ShowtimesService,
+        private readonly ticketsService: TicketsService,
+        @InjectCache('showtime-creation') private readonly cache: CacheService
+    ) {}
+
+    bind() {
+        return {
+            compensate: this.compensate.bind(this),
+            emitStatusChanged: this.emitStatusChanged.bind(this),
+            validateAndCreate: this.validateAndCreate.bind(this)
+        }
+    }
+
+    async emitStatusChanged(payload: ShowtimeCreationEvent): Promise<void> {
+        await this.events.emitStatusChanged(payload)
+    }
+
+    async validateAndCreate(
+        input: LegacyShowtimeCreationWorkflowInput
+    ): Promise<ValidateAndCreateResult> {
+        const { createDto, sagaId } = JsonUtil.reviveDates(input)
+
+        return this.cache.withLockBlocking<ValidateAndCreateResult>(
+            LEGACY_VALIDATE_CREATE_LOCK_KEY,
+            LEGACY_VALIDATE_CREATE_LOCK_TTL_MS,
+            async () => {
+                const { conflictingShowtimes, isValid } =
+                    await this.validatorService.validate(createDto)
+
+                if (isValid) {
+                    const creationResult = await this.creatorService.create(createDto, sagaId)
+                    return { kind: 'succeeded', ...creationResult }
+                }
+                return { conflictingShowtimes, kind: 'failed' }
+            },
+            { waitMs: LEGACY_VALIDATE_CREATE_LOCK_WAIT_MS }
+        )
+    }
+
+    async compensate(sagaId: string): Promise<void> {
+        await this.cache.withLockBlocking(
+            LEGACY_VALIDATE_CREATE_LOCK_KEY,
+            LEGACY_VALIDATE_CREATE_LOCK_TTL_MS,
+            async () => {
+                const targets = ['tickets', 'showtimes'] as const
+                const results = await Promise.allSettled([
+                    this.ticketsService.deleteBySagaIds([sagaId]),
+                    this.showtimesService.deleteBySagaIds([sagaId])
+                ])
+                const failures = results
+                    .map((result, i) => ({ result, target: targets[i] }))
+                    .filter(({ result }) => result.status === 'rejected')
+
+                if (0 < failures.length) {
+                    const reasons = failures
+                        .map(
+                            ({ result, target }) =>
+                                `${target}=${getByPath(result, 'reason.message', 'unknown')}`
+                        )
+                        .join(', ')
+                    throw new Error(`compensate failed (sagaId=${sagaId}): ${reasons}`)
+                }
+
+                this.logger.log('compensate completed', { sagaId })
+            },
+            { waitMs: LEGACY_VALIDATE_CREATE_LOCK_WAIT_MS }
+        )
+    }
+}

--- a/apps/api/src/services/application/showtime-creation/worker/legacy-lock.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/legacy-lock.ts
@@ -1,0 +1,5 @@
+// v1 binary와 rolling overlap 중인 v2 Activity가 같은 임계 구역을 사용하기 위한 호환 fence다.
+// original task queue의 실행이 완전히 drain된 것을 확인한 뒤 별도 릴리스에서 제거할 수 있다.
+export const LEGACY_VALIDATE_CREATE_LOCK_KEY = 'validate-and-create'
+export const LEGACY_VALIDATE_CREATE_LOCK_TTL_MS = 15 * 60 * 1000
+export const LEGACY_VALIDATE_CREATE_LOCK_WAIT_MS = 10 * 60 * 1000

--- a/apps/api/src/services/application/showtime-creation/worker/legacy-types.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/legacy-types.ts
@@ -1,0 +1,10 @@
+// v1 Temporal history의 wire shape를 동결한다. DTO가 바뀌어도 drain worker 계약은 유지한다.
+export type LegacyShowtimeCreationWorkflowInput = {
+    createDto: {
+        durationInMinutes: number
+        movieId: string
+        startTimes: Date[]
+        theaterIds: string[]
+    }
+    sagaId: string
+}

--- a/apps/api/src/services/application/showtime-creation/worker/types.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/types.ts
@@ -1,12 +1,3 @@
-import { getProjectId } from 'config'
 import type { BulkCreateShowtimesDto } from '../dtos'
 
 export type ShowtimeCreationWorkflowInput = { createDto: BulkCreateShowtimesDto; sagaId: string }
-
-/**
- * 작업 큐 이름에 `PROJECT_ID`를 포함해 병렬 테스트 워커의 워크플로 실행 공간을 분리한다.
- * 운영에서는 `PROJECT_ID`가 고정되어 큐 이름도 안정적으로 유지된다.
- */
-export function getShowtimeCreationTaskQueue() {
-    return `showtime-creation-${getProjectId()}`
-}

--- a/apps/api/src/services/application/showtime-creation/worker/workflow-v2.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/workflow-v2.ts
@@ -1,0 +1,62 @@
+import { extractRootMessage, proxyActivities } from '@mannercode/temporal-sandbox'
+import type { ShowtimeCreationActivities } from './activities'
+import type { ShowtimeCreationWorkflowInput } from './types'
+
+// 검증·생성은 sagaId를 멱등 키로 사용하므로 일시적인 워커/네트워크 장애 뒤 다시 실행해도 안전하다.
+// heartbeat로 멈춘 시도를 빠르게 감지하고, 구독자의 5분 제한 안에서 모든 시도와 재시도를 끝낸다.
+const { validateAndCreate } = proxyActivities<ReturnType<ShowtimeCreationActivities['bind']>>({
+    heartbeatTimeout: '30 seconds',
+    scheduleToCloseTimeout: '195 seconds',
+    startToCloseTimeout: '1 minute',
+    // 첫 worker가 lock을 쥔 채 죽어도 55초 TTL 뒤 남은 시도가 복구할 수 있어야 한다.
+    retry: {
+        initialInterval: '1 second',
+        maximumAttempts: 4,
+        nonRetryableErrorTypes: ['BadRequestException', 'NotFoundException']
+    }
+})
+
+// 상태 알림은 같은 요청을 다시 실행해도 결과가 달라지지 않아 자동 재시도한다.
+// 구독자는 사가 이벤트를 최대 5분 기다린다(race 테스트의 SSE_DEADLINE_MS).
+// 일시적인 발행 지연이 그 안에 회복되도록 한 번의 제한 시간은 짧게, 재시도 간격은 빠르게 둔다.
+const { emitStatusChanged } = proxyActivities<ReturnType<ShowtimeCreationActivities['bind']>>({
+    scheduleToCloseTimeout: '35 seconds',
+    startToCloseTimeout: '10 seconds',
+    retry: { maximumAttempts: 3, initialInterval: '1 second' }
+})
+
+export async function showtimeCreationWorkflowV2(
+    input: ShowtimeCreationWorkflowInput
+): Promise<void> {
+    // 상태값은 다른 모듈의 타입과 맞춰 문자열로 직접 적는다.
+    // 이 파일은 격리된 실행 환경에서 묶이므로, enum을 가져오다가 NestJS 코드까지 포함되면 빌드에 실패한다.
+    await emitStatusChanged({ sagaId: input.sagaId, status: 'processing' })
+
+    let result: Awaited<ReturnType<typeof validateAndCreate>>
+    try {
+        result = await validateAndCreate(input)
+    } catch (error: unknown) {
+        // 검증·생성은 한 MongoDB transaction이므로 실패한 시도의 부분 데이터는 커밋되지 않는다.
+        await emitStatusChanged({
+            message: extractRootMessage(error),
+            sagaId: input.sagaId,
+            status: 'error'
+        })
+        return
+    }
+
+    if (result.kind === 'succeeded') {
+        await emitStatusChanged({
+            createdShowtimeCount: result.createdShowtimeCount,
+            createdTicketCount: result.createdTicketCount,
+            sagaId: input.sagaId,
+            status: 'succeeded'
+        })
+    } else {
+        await emitStatusChanged({
+            conflictingShowtimes: result.conflictingShowtimes,
+            sagaId: input.sagaId,
+            status: 'failed'
+        })
+    }
+}

--- a/apps/api/src/services/application/showtime-creation/worker/workflow.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/workflow.ts
@@ -1,17 +1,14 @@
 import { extractRootMessage, proxyActivities } from '@mannercode/temporal-sandbox'
-import type { ShowtimeCreationActivities } from './activities'
-import type { ShowtimeCreationWorkflowInput } from './types'
+import type { LegacyShowtimeCreationActivities } from './legacy-activities'
+import type { LegacyShowtimeCreationWorkflowInput } from './legacy-types'
 
-// 검증 후 생성하는 작업은 중간에 실패한 뒤 다시 실행하면 중복 생성될 수 있어 자동 재시도를 끈다.
-// 잠금 대기는 최대 10분이므로 실행 제한 시간은 더 길게 둔다.
-const { validateAndCreate } = proxyActivities<ReturnType<ShowtimeCreationActivities['bind']>>({
-    startToCloseTimeout: '15 minutes',
-    retry: { maximumAttempts: 1 }
-})
+// 이 v1 정의는 이미 실행 중인 Temporal history를 재생하기 위한 호환 코드다.
+// timeout/retry/activity command를 바꾸면 결정성이 깨지므로 v1 queue가 완전히 drain될 때까지 동결한다.
+const { validateAndCreate } = proxyActivities<ReturnType<LegacyShowtimeCreationActivities['bind']>>(
+    { startToCloseTimeout: '15 minutes', retry: { maximumAttempts: 1 } }
+)
 
-// 실패 정리는 멱등이라 자동 재시도한다.
-// 좀비가 된 validateAndCreate와 직렬화하려고 같은 분산 락을 기다리므로, 한 번의 제한 시간도 validateAndCreate와 같게 둔다.
-const { compensate } = proxyActivities<ReturnType<ShowtimeCreationActivities['bind']>>({
+const { compensate } = proxyActivities<ReturnType<LegacyShowtimeCreationActivities['bind']>>({
     startToCloseTimeout: '15 minutes',
     retry: { maximumAttempts: 3, initialInterval: '1 second' }
 })
@@ -19,13 +16,15 @@ const { compensate } = proxyActivities<ReturnType<ShowtimeCreationActivities['bi
 // 상태 알림은 같은 요청을 다시 실행해도 결과가 달라지지 않아 자동 재시도한다.
 // 구독자는 사가 이벤트를 최대 5분 기다린다(race 테스트의 SSE_DEADLINE_MS).
 // 일시적인 발행 지연이 그 안에 회복되도록 한 번의 제한 시간은 짧게, 재시도 간격은 빠르게 둔다.
-const { emitStatusChanged } = proxyActivities<ReturnType<ShowtimeCreationActivities['bind']>>({
-    startToCloseTimeout: '30 seconds',
-    retry: { maximumAttempts: 3, initialInterval: '1 second' }
-})
+const { emitStatusChanged } = proxyActivities<ReturnType<LegacyShowtimeCreationActivities['bind']>>(
+    {
+        startToCloseTimeout: '30 seconds',
+        retry: { maximumAttempts: 3, initialInterval: '1 second' }
+    }
+)
 
 export async function showtimeCreationWorkflow(
-    input: ShowtimeCreationWorkflowInput
+    input: LegacyShowtimeCreationWorkflowInput
 ): Promise<void> {
     // 상태값은 다른 모듈의 타입과 맞춰 문자열로 직접 적는다.
     // 이 파일은 격리된 실행 환경에서 묶이므로, enum을 가져오다가 NestJS 코드까지 포함되면 빌드에 실패한다.
@@ -49,8 +48,6 @@ export async function showtimeCreationWorkflow(
             })
         }
     } catch (error: unknown) {
-        // 정리를 마친 뒤에 종료를 알린다 — error 이벤트를 받았다면 보상까지 끝난 상태다.
-        // 보상이 재시도 끝에 실패하면 이벤트 없이 워크플로 실패로 남아 운영자에게 드러난다.
         await compensate(input.sagaId)
         await emitStatusChanged({
             message: extractRootMessage(error),

--- a/apps/api/src/services/core/movies/movies.service.ts
+++ b/apps/api/src/services/core/movies/movies.service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose'
 import { ensure, mapDocToDto, pickIds, uniq } from '@mannercode/common'
 import {
     BadRequestException,
@@ -72,8 +73,12 @@ export class MoviesService {
         }
     }
 
-    async allExist(movieIds: string[]): Promise<boolean> {
-        return this.moviesRepository.allExist(movieIds)
+    async allExist(
+        movieIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<boolean> {
+        return this.moviesRepository.allExist(movieIds, session, signal)
     }
 
     async finalizeUpload(movieId: string, assetId: string): Promise<void> {

--- a/apps/api/src/services/core/showtimes/models/showtime.ts
+++ b/apps/api/src/services/core/showtimes/models/showtime.ts
@@ -26,5 +26,5 @@ export const ShowtimeSchema = createCrudSchema(Showtime)
 // 이 스키마는 완전 삭제를 쓰므로 다른 도메인과 달리 `deletedAt` 필터가 붙지 않는다.
 // theaterId와 startTime만으로 접근 경로를 만든다.
 ShowtimeSchema.index({ theaterId: 1, startTime: 1 })
-// showtime-creation 보상 처리에서 사가가 만든 상영을 한 번에 찾는 경로이다.
+// showtime-creation 결과 확인과 운영 진단에서 사가가 만든 상영을 한 번에 찾는 경로이다.
 ShowtimeSchema.index({ sagaId: 1 })

--- a/apps/api/src/services/core/showtimes/showtimes.repository.ts
+++ b/apps/api/src/services/core/showtimes/showtimes.repository.ts
@@ -7,7 +7,7 @@ import {
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
-import { Model } from 'mongoose'
+import { ClientSession, Model } from 'mongoose'
 import { CreateShowtimeDto, SearchShowtimesDto } from './dtos'
 import { Showtime } from './models'
 
@@ -21,11 +21,19 @@ export class ShowtimesRepository extends CrudRepository<Showtime> {
         super(model, config.http.paginationDefaultSize, config.http.paginationMaxSize)
     }
 
-    async deleteBySagaIds(sagaIds: string[]) {
-        await this.model.deleteMany({ sagaId: { $in: sagaIds } })
+    async deleteBySagaIds(
+        sagaIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        await this.model.deleteMany({ sagaId: { $in: sagaIds } }, { session, signal })
     }
 
-    async createMany(createDtos: CreateShowtimeDto[]) {
+    async createMany(
+        createDtos: CreateShowtimeDto[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
         const showtimes = createDtos.map((dto) => {
             const doc = this.newDocument()
             doc.sagaId = dto.sagaId
@@ -37,7 +45,7 @@ export class ShowtimesRepository extends CrudRepository<Showtime> {
             return doc
         })
 
-        await this.saveMany(showtimes)
+        await this.saveMany(showtimes, session, signal)
     }
 
     async existsByMovieIds(movieIds: string[]): Promise<boolean> {
@@ -50,10 +58,18 @@ export class ShowtimesRepository extends CrudRepository<Showtime> {
         return !!found
     }
 
-    async search(searchDto: SearchShowtimesDto) {
+    async search(
+        searchDto: SearchShowtimesDto,
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
         const query = this.buildQuery(searchDto)
 
-        const showtimes = await this.model.find(query).sort({ startTime: 1 }).lean().exec()
+        const showtimes = await this.model
+            .find(query, null, { session, signal })
+            .sort({ startTime: 1 })
+            .lean()
+            .exec()
         return leanArrayToPublic<Showtime>(showtimes)
     }
 

--- a/apps/api/src/services/core/showtimes/showtimes.service.ts
+++ b/apps/api/src/services/core/showtimes/showtimes.service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose'
 import { mapDocToDto } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
 import { CreateShowtimeDto, CreateShowtimesResult, SearchShowtimesDto, ShowtimeDto } from './dtos'
@@ -8,12 +9,20 @@ import { ShowtimesRepository } from './showtimes.repository'
 export class ShowtimesService {
     constructor(private readonly repository: ShowtimesRepository) {}
 
-    async deleteBySagaIds(sagaIds: string[]) {
-        await this.repository.deleteBySagaIds(sagaIds)
+    async deleteBySagaIds(
+        sagaIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        await this.repository.deleteBySagaIds(sagaIds, session, signal)
     }
 
-    async createMany(createDtos: CreateShowtimeDto[]): Promise<CreateShowtimesResult> {
-        await this.repository.createMany(createDtos)
+    async createMany(
+        createDtos: CreateShowtimeDto[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<CreateShowtimesResult> {
+        await this.repository.createMany(createDtos, session, signal)
 
         return { count: createDtos.length }
     }
@@ -36,8 +45,12 @@ export class ShowtimesService {
         return this.toDtos(showtimes)
     }
 
-    async search(searchDto: SearchShowtimesDto) {
-        const showtimes = await this.repository.search(searchDto)
+    async search(
+        searchDto: SearchShowtimesDto,
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        const showtimes = await this.repository.search(searchDto, session, signal)
 
         return this.toDtos(showtimes)
     }

--- a/apps/api/src/services/core/theaters/models/theater.ts
+++ b/apps/api/src/services/core/theaters/models/theater.ts
@@ -21,6 +21,11 @@ export class Theater extends CrudSchema {
 
     @Prop({ _id: false, required: true, type: Object })
     seatmap: Seatmap
+
+    // 상영 검증과 생성을 MongoDB 트랜잭션 안에서 극장 단위로 직렬화하는 내부 버전이다.
+    // 기존 문서에 필드가 없어도 $inc가 0에서 시작하므로 별도 데이터 마이그레이션이 필요 없다.
+    @Prop({ default: 0, required: true, select: false })
+    showtimeScheduleVersion: number
 }
 export const TheaterSchema = createCrudSchema(Theater)
 

--- a/apps/api/src/services/core/theaters/theaters.repository.ts
+++ b/apps/api/src/services/core/theaters/theaters.repository.ts
@@ -2,12 +2,14 @@ import {
     QueryBuilderOptions,
     assignIfDefined,
     CrudRepository,
-    QueryBuilder
+    objectIds,
+    QueryBuilder,
+    uniq
 } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
-import { Model } from 'mongoose'
+import { ClientSession, Model } from 'mongoose'
 import { CreateTheaterDto, SearchTheatersPageDto, UpdateTheaterDto } from './dtos'
 import { Theater } from './models'
 
@@ -29,6 +31,24 @@ export class TheatersRepository extends CrudRepository<Theater> {
         await theater.save()
 
         return theater.toJSON()
+    }
+
+    async acquireShowtimeScheduleGuards(
+        theaterIds: string[],
+        session: ClientSession,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        // 실제 Theater 문서를 쓰기 충돌 지점으로 사용한다. 같은 극장을 포함하는 두 트랜잭션은
+        // 이 갱신에서 직렬화되고, 드라이버는 TransientTransactionError를 새 snapshot으로 재시도한다.
+        const ids = objectIds(uniq(theaterIds))
+        const options = { session, signal }
+        const result = await this.model.updateMany(
+            { _id: { $in: ids } },
+            { $inc: { showtimeScheduleVersion: 1 } },
+            options
+        )
+
+        return result.matchedCount === ids.length
     }
 
     async searchPage(searchDto: SearchTheatersPageDto) {

--- a/apps/api/src/services/core/theaters/theaters.service.ts
+++ b/apps/api/src/services/core/theaters/theaters.service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose'
 import { ensure, mapDocToDto } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
 import { CreateTheaterDto, SearchTheatersPageDto, UpdateTheaterDto, TheaterDto } from './dtos'
@@ -18,12 +19,28 @@ export class TheatersService {
         await this.repository.deleteByIds(theaterIds)
     }
 
-    async allExist(theaterIds: string[]) {
-        return this.repository.allExist(theaterIds)
+    async acquireShowtimeScheduleGuards(
+        theaterIds: string[],
+        session: ClientSession,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        return this.repository.acquireShowtimeScheduleGuards(theaterIds, session, signal)
     }
 
-    async getMany(theaterIds: string[]) {
-        const theaters = await this.repository.getByIds(theaterIds)
+    async allExist(
+        theaterIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        return this.repository.allExist(theaterIds, session, signal)
+    }
+
+    async getMany(
+        theaterIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        const theaters = await this.repository.getByIds(theaterIds, session, signal)
 
         const theaterDtos = this.toDtos(theaters)
         return theaterDtos

--- a/apps/api/src/services/core/tickets/models/ticket.ts
+++ b/apps/api/src/services/core/tickets/models/ticket.ts
@@ -32,5 +32,5 @@ export const TicketSchema = createCrudSchema(Ticket)
 // 특정 상영의 티켓 조회와 판매 현황 집계가 가장 자주 쓰는 접근 경로이다.
 // 소프트 삭제 미들웨어가 모든 조회에 `deletedAt: null`을 추가하므로, 이 필드를 앞에 두어 같은 인덱스가 삭제 필터와 showtime 필터를 함께 처리하게 한다.
 TicketSchema.index({ deletedAt: 1, showtimeId: 1 })
-// showtime-creation 보상 처리에서 사가가 만든 티켓을 한 번에 찾는 경로이다.
+// showtime-creation 결과 확인과 운영 진단에서 사가가 만든 티켓을 한 번에 찾는 경로이다.
 TicketSchema.index({ sagaId: 1 })

--- a/apps/api/src/services/core/tickets/tickets.repository.ts
+++ b/apps/api/src/services/core/tickets/tickets.repository.ts
@@ -8,7 +8,7 @@ import {
 import { ConflictException, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
-import { Model } from 'mongoose'
+import { ClientSession, Model } from 'mongoose'
 import {
     AggregateTicketSalesDto,
     CreateTicketDto,
@@ -27,8 +27,12 @@ export class TicketsRepository extends CrudRepository<Ticket> {
         super(model, config.http.paginationDefaultSize, config.http.paginationMaxSize)
     }
 
-    async deleteBySagaIds(sagaIds: string[]) {
-        await this.model.deleteMany({ sagaId: { $in: sagaIds } })
+    async deleteBySagaIds(
+        sagaIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        await this.model.deleteMany({ sagaId: { $in: sagaIds } }, { session, signal })
     }
 
     async aggregateSales(aggregateDto: AggregateTicketSalesDto) {
@@ -57,7 +61,11 @@ export class TicketsRepository extends CrudRepository<Ticket> {
         return showtimeTicketSalesArray
     }
 
-    async createMany(createDtos: CreateTicketDto[]) {
+    async createMany(
+        createDtos: CreateTicketDto[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
         const tickets = createDtos.map((dto) => {
             const ticket = this.newDocument()
             ticket.sagaId = dto.sagaId
@@ -70,7 +78,7 @@ export class TicketsRepository extends CrudRepository<Ticket> {
             return ticket
         })
 
-        await this.saveMany(tickets)
+        await this.saveMany(tickets, session, signal)
     }
 
     async search(searchDto: SearchTicketsDto) {

--- a/apps/api/src/services/core/tickets/tickets.service.ts
+++ b/apps/api/src/services/core/tickets/tickets.service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from 'mongoose'
 import { mapDocToDto } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
 import {
@@ -14,8 +15,12 @@ import { TicketsRepository } from './tickets.repository'
 export class TicketsService {
     constructor(private readonly repository: TicketsRepository) {}
 
-    async deleteBySagaIds(sagaIds: string[]) {
-        await this.repository.deleteBySagaIds(sagaIds)
+    async deleteBySagaIds(
+        sagaIds: string[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
+        await this.repository.deleteBySagaIds(sagaIds, session, signal)
     }
 
     async aggregateSales(aggregateDto: AggregateTicketSalesDto) {
@@ -23,8 +28,12 @@ export class TicketsService {
         return salesByShowtime
     }
 
-    async createMany(createDtos: CreateTicketDto[]): Promise<CreateTicketsResult> {
-        await this.repository.createMany(createDtos)
+    async createMany(
+        createDtos: CreateTicketDto[],
+        session: ClientSession | undefined = undefined,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<CreateTicketsResult> {
+        await this.repository.createMany(createDtos, session, signal)
 
         return { count: createDtos.length }
     }

--- a/libs/common/src/cache/__tests__/cache.service.spec.ts
+++ b/libs/common/src/cache/__tests__/cache.service.spec.ts
@@ -254,6 +254,32 @@ describe('CacheService', () => {
             })
             expect(result).toBe(1)
         })
+
+        it('이미 취소된 대기는 락을 실행하지 않고 즉시 중단한다', async () => {
+            const controller = new AbortController()
+            const runner = jest.fn(async () => 1)
+            controller.abort(new Error('activity cancelled'))
+
+            await expect(
+                fix.cacheService.withLockBlocking('job', 5_000, runner, {
+                    signal: controller.signal
+                })
+            ).rejects.toThrow('activity cancelled')
+            expect(runner).not.toHaveBeenCalled()
+        })
+
+        it('락을 기다리는 중 취소되면 다음 획득을 시도하지 않는다', async () => {
+            await fix.cacheService.set('lock:job', 'other', 10_000)
+            const controller = new AbortController()
+            const waiting = fix.cacheService.withLockBlocking('job', 5_000, async () => 'unused', {
+                pollMs: 1000,
+                signal: controller.signal
+            })
+
+            setTimeout(() => controller.abort(new Error('activity cancelled')), 20)
+
+            await expect(waiting).rejects.toThrow('The operation was aborted')
+        })
     })
 
     describe('복구 경로', () => {

--- a/libs/common/src/cache/cache.service.ts
+++ b/libs/common/src/cache/cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import Redis from 'ioredis'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { defaultTo } from '../utils'
 
 @Injectable()
@@ -91,16 +92,25 @@ export class CacheService {
         key: string,
         ttlMs: number,
         fn: () => Promise<T> | T,
-        { pollMs = 50, waitMs = 2 * 60 * 1000 }: { pollMs?: number; waitMs?: number } = {}
+        {
+            pollMs = 50,
+            signal,
+            waitMs = 2 * 60 * 1000
+        }: { pollMs?: number; signal?: AbortSignal; waitMs?: number } = {}
     ): Promise<T> {
         const deadline = Date.now() + waitMs
         for (;;) {
-            const attempt = await this.withLock(key, ttlMs, fn)
+            signal?.throwIfAborted()
+            // Redis SET을 기다리는 동안 취소됐을 수 있으므로 실제 callback 진입 직전에도 확인한다.
+            const attempt = await this.withLock(key, ttlMs, () => {
+                signal?.throwIfAborted()
+                return fn()
+            })
             if (attempt.ran) return attempt.result
             if (Date.now() >= deadline) {
                 throw new Error(`withLockBlocking: could not acquire '${key}' within ${waitMs}ms`)
             }
-            await new Promise((r) => setTimeout(r, pollMs))
+            await sleep(pollMs, undefined, { signal })
         }
     }
 

--- a/libs/common/src/mongoose/crud.repository.ts
+++ b/libs/common/src/mongoose/crud.repository.ts
@@ -12,7 +12,11 @@ import { MongooseErrors } from './errors'
 import { objectId, objectIds } from './mongoose.util'
 
 type BulkSaveDocs<Doc> = Parameters<Model<Doc>['bulkSave']>[0]
+type BulkSaveOptions<Doc> = NonNullable<Parameters<Model<Doc>['bulkSave']>[1]> & {
+    signal?: AbortSignal
+}
 type SessionArg = ClientSession | undefined
+type TransactionOptions = NonNullable<Parameters<ClientSession['withTransaction']>[1]>
 
 const defaultLeanOptions = {}
 
@@ -55,13 +59,17 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
         return { deletedCount }
     }
 
-    async allExist(ids: string[], session: SessionArg = undefined) {
+    async allExist(
+        ids: string[],
+        session: SessionArg = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
         const uniqueIds = uniq(ids)
         if (uniqueIds.length === 0) return true
 
         const count = await this.model.countDocuments(
             { _id: { $in: objectIds(uniqueIds) } } as QueryFilter<Doc>,
-            { session }
+            { session, signal }
         )
         return count === uniqueIds.length
     }
@@ -74,9 +82,13 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
         return leanOneToPublic<Doc>(doc)
     }
 
-    async findByIds(ids: string[], session: SessionArg = undefined): Promise<Doc[]> {
+    async findByIds(
+        ids: string[],
+        session: SessionArg = undefined,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<Doc[]> {
         const docs = await this.model
-            .find({ _id: { $in: objectIds(ids) } } as QueryFilter<Doc>, null, { session })
+            .find({ _id: { $in: objectIds(ids) } } as QueryFilter<Doc>, null, { session, signal })
             .lean(defaultLeanOptions)
 
         return leanArrayToPublic<Doc>(docs)
@@ -140,12 +152,16 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
         return doc
     }
 
-    async getByIds(ids: string[], session: SessionArg = undefined) {
+    async getByIds(
+        ids: string[],
+        session: SessionArg = undefined,
+        signal: AbortSignal | undefined = undefined
+    ) {
         const uniqueIds = uniq(ids)
 
         Assume.equalLength(uniqueIds, ids, `Duplicate IDs detected and removed:${ids}`)
 
-        const docs = await this.findByIds(uniqueIds, session)
+        const docs = await this.findByIds(uniqueIds, session, signal)
 
         const notFoundIds = differenceWith(
             uniqueIds,
@@ -170,10 +186,16 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
         await this.model.createIndexes()
     }
 
-    async saveMany(docs: BulkSaveDocs<Doc>, session: SessionArg = undefined): Promise<void> {
-        const { deletedCount, insertedCount, matchedCount } = await this.model.bulkSave(docs, {
-            session
-        })
+    async saveMany(
+        docs: BulkSaveDocs<Doc>,
+        session: SessionArg = undefined,
+        signal: AbortSignal | undefined = undefined
+    ): Promise<void> {
+        const options: BulkSaveOptions<Doc> = { session, signal }
+        const { deletedCount, insertedCount, matchedCount } = await this.model.bulkSave(
+            docs,
+            options
+        )
 
         Require.equals(
             docs.length,
@@ -182,11 +204,14 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
         )
     }
 
-    async withTransaction<T>(callback: (session: ClientSession) => Promise<T>): Promise<T> {
+    async withTransaction<T>(
+        callback: (session: ClientSession) => Promise<T>,
+        options: TransactionOptions = {}
+    ): Promise<T> {
         // 드라이버가 일시 충돌은 트랜잭션 전체를, 불명확한 커밋은 커밋 단계만 재시도한다.
         const session = await this.model.startSession()
         try {
-            return await session.withTransaction(callback)
+            return await session.withTransaction(callback, options)
         } finally {
             await session.endSession()
         }

--- a/libs/common/src/temporal/temporal-worker.service.ts
+++ b/libs/common/src/temporal/temporal-worker.service.ts
@@ -18,6 +18,10 @@ export class TemporalWorkerService implements OnModuleInit, OnModuleDestroy {
         this.worker = await Worker.create({
             activities: this.options.activities,
             connection: this.connection,
+            maxConcurrentActivityTaskExecutions: this.options.maxConcurrentActivityTaskExecutions,
+            maxConcurrentActivityTaskPolls: this.options.maxConcurrentActivityTaskPolls,
+            maxConcurrentWorkflowTaskExecutions: this.options.maxConcurrentWorkflowTaskExecutions,
+            maxConcurrentWorkflowTaskPolls: this.options.maxConcurrentWorkflowTaskPolls,
             namespace: this.options.namespace,
             taskQueue: this.options.taskQueue,
             workflowBundle: { code: readFileSync(this.options.workflowBundlePath, 'utf8') }

--- a/libs/common/src/temporal/temporal.types.ts
+++ b/libs/common/src/temporal/temporal.types.ts
@@ -8,6 +8,10 @@ export type TemporalClientModuleAsyncOptions = {
 export type TemporalWorkerOptions = {
     activities: Record<string, (...args: any[]) => any>
     address: string
+    maxConcurrentActivityTaskExecutions?: number
+    maxConcurrentActivityTaskPolls?: number
+    maxConcurrentWorkflowTaskExecutions?: number
+    maxConcurrentWorkflowTaskPolls?: number
     namespace: string
     taskQueue: string
     workflowBundlePath: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -9934,9 +9934,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## 문제

재시도, ACK 유실, 동시 실행 상황에서 showtime 생성이 부분 반영되거나 중복 실행될 수 있었습니다.

## 변경

- showtime 생성 전체를 MongoDB 트랜잭션으로 묶고 theater 문서 버전 가드로 겹치는 스케줄 쓰기를 직렬화
- saga ID와 입력 해시를 저장하는 고유 operation 레코드로 재시도 및 ACK 유실을 멱등 처리
- repository/service 계층에 Mongo session과 AbortSignal 전달
- Temporal V2 workflow/queue와 제한된 retry/timeout/heartbeat 정책 추가
- 배포 중 기존 history를 처리할 수 있도록 v1 workflow/activity/worker 호환 경로 유지
- 입력 크기 제한과 실패 주입/동시성/롤백/호환성 회귀 테스트 보강
- package-lock의 fast-uri를 3.1.5로 갱신

## 검증

- npm run atoz: 통과
- API: 31 suites / 311 tests
- Common: 43 suites / 629 tests
- Testing: 10 suites / 58 tests
- API docs: 76 passed / 0 failed
- 4-replica deployment verification: 통과
- npm audit: 0 vulnerabilities

## 배포 메모

롤링 배포에서는 기존 v1 task queue/history가 모두 소진될 때까지 legacy worker를 함께 유지해야 합니다.