### PR TITLE
fix: recover ambiguous user creation writes

### DIFF
--- a/apps/api/src/services/core/users/__tests__/users-write-concern-recovery.spec.ts
+++ b/apps/api/src/services/core/users/__tests__/users-write-concern-recovery.spec.ts
@@ -1,0 +1,129 @@
+import { ConflictException } from '@nestjs/common'
+import { deleteModel, model, Types } from 'mongoose'
+import { type User, UserSchema } from '../models'
+import { UsersRepository } from '../users.repository'
+import { UsersService } from '../users.service'
+
+const MODEL_NAME = 'UserWriteConcernRecoverySpec'
+const userModel = model<User>(MODEL_NAME, UserSchema.clone())
+
+describe('user create write concern recovery', () => {
+    const createDto = {
+        birthDate: new Date('1990-01-01'),
+        email: 'ambiguous@example.com',
+        name: 'ambiguous',
+        password: 'password'
+    }
+
+    let repository: UsersRepository
+    let service: UsersService
+
+    beforeEach(() => {
+        repository = new UsersRepository(userModel, {
+            http: { paginationDefaultSize: 10, paginationMaxSize: 100 }
+        } as any)
+        service = new UsersService(repository, {
+            hash: jest.fn().mockResolvedValue('hashed-password')
+        } as any)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+    })
+
+    afterAll(() => {
+        deleteModel(MODEL_NAME)
+    })
+
+    it('wtimeout 뒤 majority read에서 같은 시도 _id가 보이면 생성 성공으로 복구한다', async () => {
+        const originalError = writeConcernTimeoutError()
+        let attemptId: Types.ObjectId | undefined
+        jest.spyOn(userModel.prototype, 'save').mockImplementation(function (this: {
+            _id: Types.ObjectId
+        }) {
+            attemptId = this._id
+            return Promise.reject(originalError)
+        })
+        const findOne = jest
+            .spyOn(userModel.collection, 'findOne')
+            .mockImplementation(async () => persistedUser(attemptId))
+
+        const result = await service.create(createDto)
+
+        expect(result).toEqual({
+            birthDate: createDto.birthDate,
+            email: createDto.email,
+            id: attemptId?.toString(),
+            name: createDto.name
+        })
+        expect(findOne).toHaveBeenCalledWith(
+            { deletedAt: null, email: createDto.email },
+            expect.objectContaining({
+                maxTimeMS: expect.any(Number),
+                readConcern: { level: 'majority' },
+                timeoutMS: expect.any(Number)
+            })
+        )
+    })
+
+    it('wtimeout 뒤 같은 이메일의 다른 _id가 보이면 409 conflict로 확정한다', async () => {
+        const originalError = writeConcernTimeoutError()
+        jest.spyOn(userModel.prototype, 'save').mockRejectedValue(originalError)
+        jest.spyOn(userModel.collection, 'findOne').mockResolvedValue(
+            persistedUser(new Types.ObjectId())
+        )
+
+        await expect(service.create(createDto)).rejects.toBeInstanceOf(ConflictException)
+    })
+
+    it('bounded majority read로 결과를 확인하지 못하면 원래 wtimeout을 전파한다', async () => {
+        jest.useFakeTimers()
+        const originalError = writeConcernTimeoutError()
+        jest.spyOn(userModel.prototype, 'save').mockRejectedValue(originalError)
+        const findOne = jest.spyOn(userModel.collection, 'findOne').mockResolvedValue(null)
+
+        const result = service.create(createDto).catch((error: unknown) => error)
+        await jest.runAllTimersAsync()
+
+        await expect(result).resolves.toBe(originalError)
+        expect(findOne).toHaveBeenCalledTimes(50)
+    })
+
+    it('majority read가 deadline을 소진하면 더 기다리지 않고 원래 wtimeout을 전파한다', async () => {
+        jest.useFakeTimers()
+        const originalError = writeConcernTimeoutError()
+        jest.spyOn(userModel.prototype, 'save').mockRejectedValue(originalError)
+        const findOne = jest.spyOn(userModel.collection, 'findOne').mockImplementation(async () => {
+            jest.setSystemTime(Date.now() + 5_000)
+            return null
+        })
+
+        const result = service.create(createDto).catch((error: unknown) => error)
+
+        await expect(result).resolves.toBe(originalError)
+        expect(findOne).toHaveBeenCalledTimes(1)
+    })
+})
+
+function persistedUser(id: Types.ObjectId | undefined) {
+    return {
+        _id: id,
+        birthDate: new Date('1990-01-01'),
+        createdAt: new Date(),
+        deletedAt: null,
+        email: 'ambiguous@example.com',
+        name: 'ambiguous',
+        password: 'hashed-password',
+        updatedAt: new Date()
+    } as any
+}
+
+function writeConcernTimeoutError() {
+    return Object.assign(new Error('waiting for replication timed out'), {
+        code: 64,
+        codeName: 'WriteConcernFailed',
+        errInfo: { wtimeout: true },
+        name: 'MongoWriteConcernError'
+    })
+}

--- a/apps/api/src/services/core/users/users.repository.ts
+++ b/apps/api/src/services/core/users/users.repository.ts
@@ -2,8 +2,11 @@ import {
     QueryBuilderOptions,
     assignIfDefined,
     CrudRepository,
+    isWriteConcernTimeoutError,
     QueryBuilder,
-    leanOneToPublic
+    leanOneToPublic,
+    leanToPublic,
+    sleep
 } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
@@ -11,6 +14,13 @@ import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
 import { Model } from 'mongoose'
 import { CreateUserDto, SearchUsersPageDto, UpdateUserDto } from './dtos'
 import { User } from './models'
+
+const CREATE_RECOVERY_POLL_MS = 100
+const CREATE_RECOVERY_READ_MAX_TIME_MS = 250
+const CREATE_RECOVERY_TIMEOUT_MS = 5_000
+
+export type CreateUserResult = { status: 'conflict' } | { status: 'created'; user: User }
+type PersistedUser = User & { _id: { toString(): string } }
 
 @Injectable()
 export class UsersRepository extends CrudRepository<User> {
@@ -22,16 +32,29 @@ export class UsersRepository extends CrudRepository<User> {
         super(model, config.http.paginationDefaultSize, config.http.paginationMaxSize)
     }
 
-    async create(createDto: CreateUserDto) {
+    async create(createDto: CreateUserDto): Promise<CreateUserResult> {
         const user = this.newDocument()
         user.name = createDto.name
         user.email = createDto.email
         user.birthDate = createDto.birthDate
         user.password = createDto.password
+        const attemptId = user._id.toString()
 
-        await user.save()
+        try {
+            await user.save()
+        } catch (error) {
+            if (!isWriteConcernTimeoutError(error)) throw error
 
-        return user.toJSON()
+            // wtimeout은 primary에 반영된 insert를 되돌리지 않는다. 같은 이메일을 다시 insert하면
+            // 성공한 자기 요청도 duplicate key가 되므로, 최초 _id를 시도 ID로 삼아 majority 결과를 확인한다.
+            const recovered = await this.recoverAmbiguousCreate(createDto.email, attemptId)
+            if (recovered) return recovered
+
+            // majority에서 결과를 확정하지 못한 경우에는 성공이나 충돌을 추측하지 않는다.
+            throw error
+        }
+
+        return { status: 'created', user: user.toJSON() }
     }
 
     async findByEmailWithPassword(email: string) {
@@ -71,6 +94,44 @@ export class UsersRepository extends CrudRepository<User> {
         await user.save()
 
         return user.toJSON()
+    }
+
+    private async recoverAmbiguousCreate(
+        email: string,
+        attemptId: string
+    ): Promise<CreateUserResult | undefined> {
+        const deadline = Date.now() + CREATE_RECOVERY_TIMEOUT_MS
+
+        while (Date.now() < deadline) {
+            try {
+                const readTimeoutMs = Math.min(
+                    CREATE_RECOVERY_READ_MAX_TIME_MS,
+                    Math.max(1, deadline - Date.now())
+                )
+                const persisted = await this.model.collection.findOne<PersistedUser>(
+                    { deletedAt: null, email },
+                    {
+                        maxTimeMS: readTimeoutMs,
+                        readConcern: { level: 'majority' },
+                        timeoutMS: readTimeoutMs
+                    }
+                )
+
+                if (persisted) {
+                    if (persisted._id.toString() !== attemptId) return { status: 'conflict' }
+
+                    return { status: 'created', user: leanToPublic(persisted) }
+                }
+            } catch {
+                // majority commit point가 아직 따라오지 않았거나 읽기가 일시 실패하면 제한 안에서 재확인한다.
+            }
+
+            const remainingMs = deadline - Date.now()
+            if (remainingMs <= 0) break
+            await sleep(Math.min(CREATE_RECOVERY_POLL_MS, remainingMs))
+        }
+
+        return undefined
     }
 
     private buildQuery(searchDto: SearchUsersPageDto, options: QueryBuilderOptions) {

--- a/apps/api/src/services/core/users/users.service.ts
+++ b/apps/api/src/services/core/users/users.service.ts
@@ -24,8 +24,11 @@ export class UsersService {
         const password = await this.authenticationService.hash(createDto.password)
 
         try {
-            const newUser = await this.repository.create({ ...createDto, password })
-            return this.toDto(newUser)
+            const result = await this.repository.create({ ...createDto, password })
+            if (result.status === 'conflict') {
+                throw new ConflictException(UserErrors.EmailAlreadyExists(createDto.email))
+            }
+            return this.toDto(result.user)
         } catch (error) {
             if (isDuplicateKeyError(error)) {
                 throw new ConflictException(UserErrors.EmailAlreadyExists(createDto.email))

--- a/libs/common/src/mongoose/__tests__/mongoose.util.spec.ts
+++ b/libs/common/src/mongoose/__tests__/mongoose.util.spec.ts
@@ -1,10 +1,12 @@
 import { BadRequestException, Logger } from '@nestjs/common'
 import { Prop, Schema } from '@nestjs/mongoose'
+import { MongoWriteConcernError } from 'mongodb'
 import { model, Types } from 'mongoose'
 import { createCrudSchema, CrudSchema } from '../crud.schema'
 import {
     assignIfDefined,
     isDuplicateKeyError,
+    isWriteConcernTimeoutError,
     mapDocToDto,
     newObjectIdString,
     objectId,
@@ -276,6 +278,69 @@ describe('isDuplicateKeyError', () => {
         expect(isDuplicateKeyError(undefined)).toBe(false)
         expect(isDuplicateKeyError('error')).toBe(false)
         expect(isDuplicateKeyError(11000)).toBe(false)
+    })
+})
+
+describe('isWriteConcernTimeoutError', () => {
+    it('MongoWriteConcernError의 wtimeout 정보를 인식한다', () => {
+        const error = new MongoWriteConcernError({
+            ok: 1,
+            writeConcernError: {
+                code: 64,
+                codeName: 'WriteConcernFailed',
+                errInfo: { wtimeout: true },
+                errmsg: 'waiting for replication timed out'
+            }
+        })
+
+        expect(isWriteConcernTimeoutError(error)).toBe(true)
+    })
+
+    it('드라이버가 errorResponse 안에 보존한 wtimeout도 인식한다', () => {
+        const error = {
+            errorResponse: {
+                code: 64,
+                codeName: 'WriteConcernFailed',
+                errInfo: { wtimeout: true }
+            },
+            name: 'MongoServerError'
+        }
+
+        expect(isWriteConcernTimeoutError(error)).toBe(true)
+    })
+
+    it('명령 결과의 writeConcernError에 담긴 timeout도 인식한다', () => {
+        const error = {
+            result: { writeConcernError: { code: 64, errmsg: 'waiting for replication timed out' } }
+        }
+
+        expect(isWriteConcernTimeoutError(error)).toBe(true)
+    })
+
+    it('wtimeout이 아닌 write concern 실패는 false를 반환한다', () => {
+        expect(
+            isWriteConcernTimeoutError({
+                code: 64,
+                codeName: 'WriteConcernFailed',
+                errInfo: { wtimeout: false },
+                message: 'write concern failed'
+            })
+        ).toBe(false)
+    })
+
+    it('write concern 오류가 아닌 객체의 wtimeout 표시는 false를 반환한다', () => {
+        expect(
+            isWriteConcernTimeoutError({ errInfo: { wtimeout: true }, name: 'OtherError' })
+        ).toBe(false)
+    })
+
+    it('순환 cause와 원시 타입을 안전하게 처리한다', () => {
+        const error: { cause?: unknown; name: string } = { name: 'OtherError' }
+        error.cause = error
+
+        expect(isWriteConcernTimeoutError(error)).toBe(false)
+        expect(isWriteConcernTimeoutError(null)).toBe(false)
+        expect(isWriteConcernTimeoutError('wtimeout')).toBe(false)
     })
 })
 

--- a/libs/common/src/mongoose/__tests__/mongoose.util.spec.ts
+++ b/libs/common/src/mongoose/__tests__/mongoose.util.spec.ts
@@ -317,6 +317,13 @@ describe('isWriteConcernTimeoutError', () => {
         expect(isWriteConcernTimeoutError(error)).toBe(true)
     })
 
+    it('대소문자가 다른 wtimeout과 write concern timeout 메시지도 인식한다', () => {
+        expect(isWriteConcernTimeoutError({ code: 64, message: 'WTIMEOUT' })).toBe(true)
+        expect(isWriteConcernTimeoutError({ code: 64, message: 'Write Concern Timed Out' })).toBe(
+            true
+        )
+    })
+
     it('wtimeout이 아닌 write concern 실패는 false를 반환한다', () => {
         expect(
             isWriteConcernTimeoutError({

--- a/libs/common/src/mongoose/mongoose.util.ts
+++ b/libs/common/src/mongoose/mongoose.util.ts
@@ -18,8 +18,6 @@ export function isDuplicateKeyError(error: unknown): boolean {
 }
 
 const WRITE_CONCERN_FAILED_CODE = 64
-const WRITE_CONCERN_TIMEOUT_MESSAGE =
-    /(?:waiting for replication|write concern).*timed out|wtimeout/i
 
 type ErrorRecord = Record<string, unknown>
 
@@ -45,8 +43,7 @@ export function isWriteConcernTimeoutError(error: unknown): boolean {
         const identifiesTimeout =
             errInfo?.wtimeout === true ||
             [record.message, record.errmsg].some(
-                (message) =>
-                    typeof message === 'string' && WRITE_CONCERN_TIMEOUT_MESSAGE.test(message)
+                (message) => typeof message === 'string' && isWriteConcernTimeoutMessage(message)
             )
 
         if (identifiesWriteConcern && identifiesTimeout) return true
@@ -62,6 +59,15 @@ export function isWriteConcernTimeoutError(error: unknown): boolean {
 
 function isErrorRecord(value: unknown): value is ErrorRecord {
     return typeof value === 'object' && value !== null
+}
+
+function isWriteConcernTimeoutMessage(value: string): boolean {
+    const message = value.toLowerCase()
+    return (
+        message.includes('wtimeout') ||
+        (message.includes('timed out') &&
+            (message.includes('waiting for replication') || message.includes('write concern')))
+    )
 }
 
 export type QueryBuilderOptions = { allowEmpty?: boolean }

--- a/libs/common/src/mongoose/mongoose.util.ts
+++ b/libs/common/src/mongoose/mongoose.util.ts
@@ -17,6 +17,53 @@ export function isDuplicateKeyError(error: unknown): boolean {
     return typeof error === 'object' && error !== null && 'code' in error && error.code === 11000
 }
 
+const WRITE_CONCERN_FAILED_CODE = 64
+const WRITE_CONCERN_TIMEOUT_MESSAGE =
+    /(?:waiting for replication|write concern).*timed out|wtimeout/i
+
+type ErrorRecord = Record<string, unknown>
+
+export function isWriteConcernTimeoutError(error: unknown): boolean {
+    const pending: { isWriteConcernField: boolean; value: unknown }[] = [
+        { isWriteConcernField: false, value: error }
+    ]
+    const visited = new Set<object>()
+
+    while (pending.length > 0) {
+        const current = pending.pop()
+        if (!current || !isErrorRecord(current.value) || visited.has(current.value)) continue
+
+        const record = current.value
+        visited.add(record)
+
+        const errInfo = isErrorRecord(record.errInfo) ? record.errInfo : undefined
+        const identifiesWriteConcern =
+            current.isWriteConcernField ||
+            record.name === 'MongoWriteConcernError' ||
+            record.code === WRITE_CONCERN_FAILED_CODE ||
+            record.codeName === 'WriteConcernFailed'
+        const identifiesTimeout =
+            errInfo?.wtimeout === true ||
+            [record.message, record.errmsg].some(
+                (message) =>
+                    typeof message === 'string' && WRITE_CONCERN_TIMEOUT_MESSAGE.test(message)
+            )
+
+        if (identifiesWriteConcern && identifiesTimeout) return true
+
+        for (const key of ['cause', 'errorResponse', 'result'] as const) {
+            pending.push({ isWriteConcernField: false, value: record[key] })
+        }
+        pending.push({ isWriteConcernField: true, value: record.writeConcernError })
+    }
+
+    return false
+}
+
+function isErrorRecord(value: unknown): value is ErrorRecord {
+    return typeof value === 'object' && value !== null
+}
+
 export type QueryBuilderOptions = { allowEmpty?: boolean }
 
 type Transform<T> = (value: T) => any


### PR DESCRIPTION
## Summary

- recover user creation after MongoDB write-concern timeouts by reading the majority-committed winner
- use the generated ObjectId as the attempt identity so the winning request returns 201 and competing requests return 409
- bound recovery reads with server and client-side deadlines, and recognize nested MongoDB write-concern timeout shapes

## Failure addressed

Test Stability run 31027895986 failed user-signup-race when concurrent inserts returned MongoWriteConcernError: waiting for replication timed out. A write-concern timeout can leave the primary write committed, so blindly retrying the insert is unsafe.

## Verification

- npm run atoz: PASS
- Temporal sandbox: 7 tests, 100% coverage
- common: 635 tests, 100% coverage
- testing: 58 tests
- API: 315 tests, 100% coverage
- Playwright: 1 test
- API docs: 76 passed, 0 failed
- npm audit: 0 vulnerabilities
- independent review: no P0/P1 findings