### PR TITLE
fix(ci): stabilize MongoDB test lifecycle

### DIFF
--- a/.github/scripts/dump-mongo-diagnostics.sh
+++ b/.github/scripts/dump-mongo-diagnostics.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_root="${WORKSPACE_ROOT:-$(cd "${script_dir}/../.." && pwd)}"
+compose_directory="${workspace_root}/infra"
+compose_file="${compose_directory}/compose.yml"
+node_diagnostics="${script_dir}/mongo-node-diagnostics.js"
+mongo_services=(mongo1 mongo2 mongo3)
+query_timeout_seconds="${MONGO_DIAGNOSTICS_TIMEOUT_SECONDS:-35}"
+
+echo "=== MongoDB diagnostics @ $(date -u +'%Y-%m-%dT%H:%M:%SZ') ==="
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is unavailable; MongoDB diagnostics skipped"
+    exit 0
+fi
+
+compose=(docker compose --project-directory "${compose_directory}" -f "${compose_file}")
+
+echo "=== MongoDB compose state ==="
+timeout 8s "${compose[@]}" ps -a "${mongo_services[@]}" 2>&1 || \
+    echo "MongoDB compose state timed out or failed"
+
+container_ids=()
+declare -A container_by_service=()
+for service in "${mongo_services[@]}"; do
+    container_id="$(timeout 5s "${compose[@]}" ps -q "${service}" 2>/dev/null || true)"
+    if [ -n "${container_id}" ]; then
+        container_by_service["${service}"]="${container_id}"
+        container_ids+=("${container_id}")
+    fi
+done
+
+if [ "${#container_ids[@]}" -gt 0 ]; then
+    timeout 8s docker inspect --format \
+        'name={{.Name}} status={{.State.Status}} running={{.State.Running}} oomKilled={{.State.OOMKilled}} exitCode={{.State.ExitCode}} restartCount={{.RestartCount}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} startedAt={{.State.StartedAt}} finishedAt={{.State.FinishedAt}}' \
+        "${container_ids[@]}" 2>&1 || echo "MongoDB docker inspect timed out or failed"
+
+    echo "=== MongoDB container resources ==="
+    timeout 10s docker stats --no-stream "${container_ids[@]}" 2>&1 || \
+        echo "MongoDB docker stats timed out or failed"
+fi
+
+echo "=== Runner pressure ==="
+if command -v uptime >/dev/null 2>&1; then
+    uptime 2>&1 || true
+fi
+if command -v free >/dev/null 2>&1; then
+    free -h 2>&1 || true
+fi
+timeout 5s df -h "${workspace_root}" 2>&1 || echo "df timed out or failed"
+if command -v vmstat >/dev/null 2>&1; then
+    timeout 5s vmstat 1 3 2>&1 || echo "vmstat timed out or failed"
+fi
+
+dump_mongo_node() {
+    local service="$1"
+    local container_id="${container_by_service[${service}]:-}"
+
+    echo "=== MongoDB node: ${service} ==="
+    if [ -z "${container_id}" ]; then
+        echo "${service} container is unavailable"
+        return
+    fi
+
+    if [ "$(timeout 5s docker inspect --format '{{.State.Running}}' "${container_id}" 2>/dev/null)" != 'true' ]; then
+        echo "${service} container is not running"
+        return
+    fi
+
+    local mongo_uri='mongodb://localhost:27016/admin?directConnection=true&serverSelectionTimeoutMS=3000&connectTimeoutMS=3000&socketTimeoutMS=5000&minPoolSize=0&maxPoolSize=1'
+    if ! timeout "${query_timeout_seconds}s" docker exec -i "${container_id}" \
+        mongosh "${mongo_uri}" --quiet --file /dev/stdin <"${node_diagnostics}"; then
+        echo "${service} diagnostics timed out or failed"
+    fi
+}
+
+if ! diagnostics_directory="$(mktemp -d)"; then
+    echo "Unable to create a temporary directory; MongoDB node queries skipped"
+    exit 0
+fi
+
+cleanup() {
+    local service
+    local output_file
+    for service in "${mongo_services[@]}"; do
+        output_file="${diagnostics_directory}/${service}.out"
+        if [ -e "${output_file}" ]; then
+            rm -- "${output_file}"
+        fi
+    done
+    rmdir -- "${diagnostics_directory}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+query_pids=()
+for service in "${mongo_services[@]}"; do
+    dump_mongo_node "${service}" >"${diagnostics_directory}/${service}.out" 2>&1 &
+    query_pids+=("$!")
+done
+
+for query_pid in "${query_pids[@]}"; do
+    wait "${query_pid}" || true
+done
+
+for service in "${mongo_services[@]}"; do
+    cat "${diagnostics_directory}/${service}.out"
+done
+
+exit 0

--- a/.github/scripts/mongo-node-diagnostics.js
+++ b/.github/scripts/mongo-node-diagnostics.js
@@ -1,0 +1,235 @@
+const attempt = (label, callback) => {
+    try {
+        return callback()
+    } catch (error) {
+        const message = error instanceof Error ? (error.stack ?? error.message) : String(error)
+        return { diagnosticError: `${label}: ${message}` }
+    }
+}
+
+const dateMillis = (value) => {
+    if (value == null) return null
+    return new Date(value.toISOString()).getTime()
+}
+
+const findPrimary = (members) => {
+    if (!Array.isArray(members)) return undefined
+    for (const member of members) {
+        if (member.stateStr === 'PRIMARY') return member
+    }
+    return undefined
+}
+
+const lagSeconds = (primaryWallTime, memberWallTime) => {
+    const primaryMillis = dateMillis(primaryWallTime)
+    const memberMillis = dateMillis(memberWallTime)
+    return primaryMillis == null || memberMillis == null
+        ? null
+        : (primaryMillis - memberMillis) / 1000
+}
+
+const helloStatus = attempt('hello', () => db.adminCommand({ hello: 1 }))
+const serverStatus = attempt('serverStatus', () => db.serverStatus())
+const replicaSetStatus = attempt('replSetGetStatus', () => db.adminCommand({ replSetGetStatus: 1 }))
+const activeOperations = attempt('currentOp', () =>
+    db
+        .aggregate(
+            [
+                { $currentOp: { allUsers: true, idleConnections: false, localOps: true } },
+                {
+                    $match: {
+                        active: true,
+                        ns: { $ne: 'local.oplog.rs' },
+                        op: { $ne: 'none' },
+                        $or: [
+                            { appName: /^nest-seed-test-/ },
+                            { waitingForFlowControl: true },
+                            { waitingForLock: true }
+                        ]
+                    }
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        appName: 1,
+                        client: 1,
+                        desc: 1,
+                        locks: 1,
+                        microsecs_running: 1,
+                        ns: 1,
+                        numYields: 1,
+                        op: 1,
+                        opid: 1,
+                        planSummary: 1,
+                        readConcern: 1,
+                        secs_running: 1,
+                        transaction: 1,
+                        waitingForFlowControl: 1,
+                        waitingForLock: 1,
+                        waitType: 1,
+                        writeConcern: 1
+                    }
+                },
+                { $sort: { secs_running: -1 } },
+                { $limit: 50 }
+            ],
+            { maxTimeMS: 3000 }
+        )
+        .toArray()
+)
+const testClientConnections = attempt('testClientConnections', () =>
+    db
+        .aggregate(
+            [
+                { $currentOp: { allUsers: true, idleConnections: true, localOps: false } },
+                { $match: { appName: /^nest-seed-test-/ } },
+                {
+                    $group: {
+                        _id: { active: '$active', appName: '$appName' },
+                        connections: { $sum: 1 },
+                        maxSecondsRunning: { $max: '$secs_running' }
+                    }
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        active: '$_id.active',
+                        appName: '$_id.appName',
+                        connections: 1,
+                        maxSecondsRunning: 1
+                    }
+                },
+                { $sort: { connections: -1, appName: 1 } },
+                { $limit: 100 }
+            ],
+            { maxTimeMS: 3000 }
+        )
+        .toArray()
+)
+
+const cache = serverStatus.wiredTiger?.cache
+const primary = findPrimary(replicaSetStatus.members)
+
+const diagnostics = {
+    capturedAt: new Date(),
+    hello:
+        helloStatus.diagnosticError == null
+            ? {
+                  isWritablePrimary: helloStatus.isWritablePrimary,
+                  lastWrite: helloStatus.lastWrite,
+                  me: helloStatus.me,
+                  primary: helloStatus.primary,
+                  secondary: helloStatus.secondary,
+                  setName: helloStatus.setName,
+                  topologyVersion: helloStatus.topologyVersion
+              }
+            : helloStatus,
+    server:
+        serverStatus.diagnosticError == null
+            ? {
+                  connections: serverStatus.connections,
+                  electionMetrics: serverStatus.electionMetrics,
+                  executionQueues: serverStatus.queues?.execution,
+                  flowControl: serverStatus.flowControl,
+                  globalLock: {
+                      activeClients: serverStatus.globalLock?.activeClients,
+                      currentQueue: serverStatus.globalLock?.currentQueue
+                  },
+                  host: serverStatus.host,
+                  ingressQueue: serverStatus.queues?.ingress,
+                  localTime: serverStatus.localTime,
+                  memory: serverStatus.mem,
+                  network: {
+                      bytesIn: serverStatus.network?.bytesIn,
+                      bytesOut: serverStatus.network?.bytesOut,
+                      ingressRequestRateLimiter: serverStatus.network?.ingressRequestRateLimiter,
+                      numRequests: serverStatus.network?.numRequests,
+                      serviceExecutors: serverStatus.network?.serviceExecutors
+                  },
+                  operationLatencies: serverStatus.opLatencies,
+                  operationWorkingTime: serverStatus.opWorkingTime,
+                  opcounters: serverStatus.opcounters,
+                  pid: serverStatus.pid,
+                  process: serverStatus.process,
+                  replication: serverStatus.repl,
+                  replicationMetrics: {
+                      apply: serverStatus.metrics?.repl?.apply,
+                      buffer: serverStatus.metrics?.repl?.buffer,
+                      heartbeat: serverStatus.metrics?.repl?.heartBeat,
+                      network: serverStatus.metrics?.repl?.network,
+                      stateTransition: serverStatus.metrics?.repl?.stateTransition,
+                      syncSource: serverStatus.metrics?.repl?.syncSource,
+                      waiters: serverStatus.metrics?.repl?.waiters,
+                      write: serverStatus.metrics?.repl?.write
+                  },
+                  storage: {
+                      cache: cache
+                          ? {
+                                applicationThreadEvictionTimeMicros:
+                                    cache['application thread time evicting (usecs)'],
+                                bytesCurrentlyInCache: cache['bytes currently in the cache'],
+                                bytesDirtyInCache: cache['tracked dirty bytes in the cache'],
+                                evictionAggressiveMode:
+                                    cache['eviction currently operating in aggressive mode'],
+                                evictionServerUnableToReachGoal:
+                                    cache['eviction server unable to reach eviction goal'],
+                                maximumBytesConfigured: cache['maximum bytes configured'],
+                                operationsTimedOutWaitingForCache:
+                                    cache['operations timed out waiting for space in cache'],
+                                pagesQueuedForEviction: cache['pages queued for eviction'],
+                                pagesQueuedForUrgentEviction:
+                                    cache['pages queued for urgent eviction']
+                            }
+                          : undefined,
+                      engine: serverStatus.storageEngine
+                  },
+                  transactions: serverStatus.transactions,
+                  uptimeSeconds: serverStatus.uptime,
+                  version: serverStatus.version
+              }
+            : serverStatus,
+    replicaSet:
+        replicaSetStatus.diagnosticError == null
+            ? {
+                  date: replicaSetStatus.date,
+                  majorityVoteCount: replicaSetStatus.majorityVoteCount,
+                  members: replicaSetStatus.members.map((member) => {
+                      return {
+                          appliedLagSeconds: lagSeconds(
+                              primary?.lastAppliedWallTime,
+                              member.lastAppliedWallTime
+                          ),
+                          durableLagSeconds: lagSeconds(
+                              primary?.lastDurableWallTime,
+                              member.lastDurableWallTime
+                          ),
+                          health: member.health,
+                          lastAppliedWallTime: member.lastAppliedWallTime,
+                          lastDurableWallTime: member.lastDurableWallTime,
+                          lastHeartbeat: member.lastHeartbeat,
+                          lastHeartbeatMessage: member.lastHeartbeatMessage,
+                          lastHeartbeatRecv: member.lastHeartbeatRecv,
+                          name: member.name,
+                          optimeDate: member.optimeDate,
+                          pingMs: member.pingMs,
+                          self: member.self ?? false,
+                          stateStr: member.stateStr,
+                          syncSourceHost: member.syncSourceHost
+                      }
+                  }),
+                  myState: replicaSetStatus.myState,
+                  optimes: {
+                      lastAppliedWallTime: replicaSetStatus.optimes?.lastAppliedWallTime,
+                      lastCommittedWallTime: replicaSetStatus.optimes?.lastCommittedWallTime,
+                      lastDurableWallTime: replicaSetStatus.optimes?.lastDurableWallTime,
+                      lastWrittenWallTime: replicaSetStatus.optimes?.lastWrittenWallTime
+                  },
+                  term: replicaSetStatus.term,
+                  writeMajorityCount: replicaSetStatus.writeMajorityCount
+              }
+            : replicaSetStatus,
+    activeOperations,
+    testClientConnections
+}
+
+print(EJSON.stringify(diagnostics, null, 0, { relaxed: true }))

--- a/.github/scripts/repeat.sh
+++ b/.github/scripts/repeat.sh
@@ -8,7 +8,7 @@ dump_postgresql_diagnostics () {
     local compose_file="${WORKSPACE_ROOT:?WORKSPACE_ROOT must be set}/infra/compose.yml"
     local postgres_id
 
-    postgres_id=$(docker compose --project-directory "${WORKSPACE_ROOT}/infra" -f "${compose_file}" ps -q temporal-postgresql 2>/dev/null || true)
+    postgres_id=$(timeout 8s docker compose --project-directory "${WORKSPACE_ROOT}/infra" -f "${compose_file}" ps -q temporal-postgresql 2>/dev/null || true)
     if [ -z "${postgres_id}" ]; then
         echo "=== PostgreSQL diagnostics unavailable: temporal-postgresql is not running ==="
         return
@@ -96,14 +96,18 @@ on_failure () {
     trap - ERR
     set +e
 
-    docker ps -a
-    docker stats -a --no-stream
+    timeout --kill-after=5s 110s \
+        bash "${WORKSPACE_ROOT}/.github/scripts/dump-mongo-diagnostics.sh" || \
+        echo "MongoDB diagnostics timed out or failed"
+    timeout 10s docker ps -a || echo "docker ps timed out or failed"
+    timeout 15s docker stats -a --no-stream || echo "docker stats timed out or failed"
     dump_postgresql_diagnostics
 
-    for id in $(docker ps -aq); do
-        name=$(docker inspect --format '{{.Name}} ({{.State.Status}})' "${id}")
+    for id in $(timeout 10s docker ps -aq); do
+        name=$(timeout 5s docker inspect --format '{{.Name}} ({{.State.Status}})' "${id}" || echo "${id} (inspect unavailable)")
         echo "========================= ${name} ========================="
-        docker logs --tail 200 "${id}"
+        timeout 15s docker logs --tail 200 "${id}" || \
+            echo "docker logs timed out or failed for ${id}"
     done
 
     exit "${exit_code}"

--- a/.github/scripts/run-with-ci-diagnostics.sh
+++ b/.github/scripts/run-with-ci-diagnostics.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+on_failure() {
+    local exit_code=$?
+
+    trap - ERR
+    set +e
+    timeout --kill-after=5s 110s bash "${script_dir}/dump-mongo-diagnostics.sh" || \
+        echo "MongoDB diagnostics timed out or failed"
+    exit "${exit_code}"
+}
+trap on_failure ERR
+
+"$@"

--- a/.github/workflows/test-atoz.yaml
+++ b/.github/workflows/test-atoz.yaml
@@ -22,9 +22,13 @@ jobs:
             - uses: actions/checkout@v7
             - name: Run in devcontainer
               uses: devcontainers/ci@v0.3
+              env:
+                  MONGO_DIAGNOSTICS_ON_TEST_FAILURE: 'true'
               with:
                   configFile: .devcontainer/devcontainer.json
                   push: never
+                  env: |
+                      MONGO_DIAGNOSTICS_ON_TEST_FAILURE
                   runCmd: |
                       set -Eeuo pipefail
-                      npm run atoz
+                      bash .github/scripts/run-with-ci-diagnostics.sh npm run atoz

--- a/.github/workflows/test-stability.yaml
+++ b/.github/workflows/test-stability.yaml
@@ -82,12 +82,14 @@ jobs:
               env:
                   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
                   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+                  MONGO_DIAGNOSTICS_ON_TEST_FAILURE: 'true'
               with:
                   configFile: .devcontainer/devcontainer.json
                   push: never
                   env: |
                       DOCKERHUB_USERNAME
                       DOCKERHUB_TOKEN
+                      MONGO_DIAGNOSTICS_ON_TEST_FAILURE
                   runCmd: |
                       set -Eeuo pipefail
                       echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     ...tsJestPreset,
     globalSetup: path.resolve(__dirname, 'jest.global.js'),
     globalTeardown: path.resolve(__dirname, 'jest.teardown.js'),
+    reporters: ['default', path.resolve(__dirname, 'scripts/jest-failure-diagnostics-reporter.js')],
     setupFilesAfterEnv: [path.resolve(__dirname, 'jest.setup.js')],
     moduleFileExtensions: ['js', 'json', 'ts'],
     rootDir: appDir,

--- a/apps/api/jest.setup.js
+++ b/apps/api/jest.setup.js
@@ -2,15 +2,31 @@ require('reflect-metadata')
 const { S3Client } = require('@aws-sdk/client-s3')
 const { setupJestLifecycle } = require('@mannercode/jest-helpers')
 const { MongoClient } = require('mongodb')
+const { createMongoDriverOptions } = require('./src/config/mongo-driver-options')
+const { registerMongoClientDiagnostics } = require('./src/modules/mongoose-setup.module')
+const {
+    attachSharedTestMongooseConnection,
+    clearSharedTestMongooseConnection
+} = require('./scripts')
+
+const sharedMongoAppName = () =>
+    `nest-seed-test-w${process.env.JEST_WORKER_ID ?? '0'}-p${process.pid}-shared`
 
 setupJestLifecycle({
     connectMongo: async (workerId) => {
         const dbName = `mongo-w${workerId}`
         process.env.MONGO_DATABASE = dbName
 
-        const client = new MongoClient(process.env.MONGO_URI)
+        const client = new MongoClient(
+            process.env.MONGO_URI,
+            createMongoDriverOptions({ appName: sharedMongoAppName() })
+        )
+        registerMongoClientDiagnostics(client, dbName, sharedMongoAppName())
         await client.connect()
         return { client, dbName }
+    },
+    afterMongoConnect: (client, dbName) => {
+        attachSharedTestMongooseConnection({ appName: sharedMongoAppName(), client, dbName })
     },
     createS3Client: () =>
         new S3Client({
@@ -30,4 +46,8 @@ setupJestLifecycle({
     onBeforeEach: (testId) => {
         process.env.PROJECT_ID = `project-${testId}`
     }
+})
+
+afterAll(() => {
+    clearSharedTestMongooseConnection()
 })

--- a/apps/api/scripts/index.d.ts
+++ b/apps/api/scripts/index.d.ts
@@ -1,0 +1,1 @@
+export * from './shared-test-mongoose-connection'

--- a/apps/api/scripts/index.js
+++ b/apps/api/scripts/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./shared-test-mongoose-connection')

--- a/apps/api/scripts/jest-failure-diagnostics-reporter.js
+++ b/apps/api/scripts/jest-failure-diagnostics-reporter.js
@@ -1,0 +1,59 @@
+const path = require('path')
+const { spawn } = require('child_process')
+
+class JestFailureDiagnosticsReporter {
+    diagnostics
+
+    enabled() {
+        return process.env.CI === 'true' || process.env.MONGO_DIAGNOSTICS_ON_TEST_FAILURE === 'true'
+    }
+
+    startDiagnostics() {
+        if (this.diagnostics) return this.diagnostics
+
+        const workspaceRoot =
+            process.env.WORKSPACE_ROOT ?? path.resolve(__dirname, '..', '..', '..')
+        const diagnosticsScript = path.join(
+            workspaceRoot,
+            '.github',
+            'scripts',
+            'dump-mongo-diagnostics.sh'
+        )
+        this.diagnostics = new Promise((resolve) => {
+            const child = spawn('timeout', ['--kill-after=5s', '110s', 'bash', diagnosticsScript], {
+                cwd: workspaceRoot,
+                env: process.env,
+                stdio: 'inherit'
+            })
+            child.once('error', () => {
+                process.stderr.write('[mongo-diagnostics] failed to start Jest diagnostics\n')
+                resolve()
+            })
+            child.once('close', (code) => {
+                if (code !== 0) {
+                    process.stderr.write(
+                        `[mongo-diagnostics] Jest diagnostics exited with code ${code ?? 'signal'}\n`
+                    )
+                }
+                resolve()
+            })
+        })
+        return this.diagnostics
+    }
+
+    onTestCaseResult(_test, testCaseResult) {
+        if (this.enabled() && testCaseResult.status === 'failed') this.startDiagnostics()
+    }
+
+    onTestFileResult(_test, testResult) {
+        const failed = testResult.numFailingTests > 0 || testResult.testExecError != null
+        if (!this.enabled() || !failed) return undefined
+        return this.startDiagnostics()
+    }
+
+    onRunComplete() {
+        return this.diagnostics
+    }
+}
+
+module.exports = JestFailureDiagnosticsReporter

--- a/apps/api/scripts/shared-test-mongoose-connection.d.ts
+++ b/apps/api/scripts/shared-test-mongoose-connection.d.ts
@@ -1,0 +1,12 @@
+import type { MongoClient } from 'mongodb'
+import type { Connection } from 'mongoose'
+
+type SharedTestMongooseConnection = { appName: string; connection: Connection; dbName: string }
+
+export function attachSharedTestMongooseConnection(options: {
+    appName: string
+    client: MongoClient
+    dbName: string
+}): void
+export function clearSharedTestMongooseConnection(): void
+export function getSharedTestMongooseConnection(): SharedTestMongooseConnection

--- a/apps/api/scripts/shared-test-mongoose-connection.js
+++ b/apps/api/scripts/shared-test-mongoose-connection.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose')
+
+const sharedConnectionKey = Symbol.for('nest-seed.shared-test-mongoose-connection')
+
+function attachSharedTestMongooseConnection({ appName, client, dbName }) {
+    const connection = mongoose
+        .createConnection()
+        .setClient(client)
+        .useDb(dbName, { useCache: true })
+    connection.config.autoCreate = true
+    connection.config.autoIndex = true
+    connection.config.bufferCommands = true
+
+    const contextConnection = new Proxy(connection, {
+        get(target, property) {
+            if (property === 'close') {
+                return async () => {
+                    await Promise.allSettled(
+                        Object.values(target.models).map((model) => model.init())
+                    )
+                    for (const modelName of target.modelNames()) {
+                        target.deleteModel(modelName)
+                    }
+                }
+            }
+
+            const value = Reflect.get(target, property, target)
+            return typeof value === 'function' ? value.bind(target) : value
+        }
+    })
+
+    globalThis[sharedConnectionKey] = { appName, connection: contextConnection, dbName }
+}
+
+function clearSharedTestMongooseConnection() {
+    delete globalThis[sharedConnectionKey]
+}
+
+function getSharedTestMongooseConnection() {
+    const shared = globalThis[sharedConnectionKey]
+    if (!shared) {
+        throw new Error('Shared test Mongoose connection is not initialized')
+    }
+    return shared
+}
+
+module.exports = {
+    attachSharedTestMongooseConnection,
+    clearSharedTestMongooseConnection,
+    getSharedTestMongooseConnection
+}

--- a/apps/api/src/__tests__/app.module.spec.ts
+++ b/apps/api/src/__tests__/app.module.spec.ts
@@ -1,9 +1,9 @@
 describe('AppModule', () => {
     it('실제 AppModule 그래프에서 모든 모듈, 컨트롤러, 가드를 주입할 수 있다', async () => {
         // `resetModules: true` 환경에서는 NestJS 내부 토큰(`ModuleRef` 등)이 두 실행 영역으로 갈라지지 않도록, 모든 모듈을 같은 그래프에서 동적으로 가져온다.
-        const { Test } = await import('@nestjs/testing')
-        const { AppModule } = await import('../app.module')
-        const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile()
-        await moduleRef.close()
+        const { createAppTestContext } = await import('./helpers')
+        const ctx = await createAppTestContext()
+
+        await ctx.close()
     })
 })

--- a/apps/api/src/__tests__/health.spec.ts
+++ b/apps/api/src/__tests__/health.spec.ts
@@ -2,13 +2,16 @@ import type { AppTestContext } from './helpers'
 
 describe('Health', () => {
     let fix: AppTestContext
+    let teardown: AppTestContext['teardown'] | undefined
 
     beforeEach(async () => {
+        teardown = undefined
         const { createAppTestContext } = await import('./helpers')
         fix = await createAppTestContext()
+        teardown = fix.teardown
     })
 
-    afterEach(() => fix.teardown())
+    afterEach(() => teardown?.())
 
     describe('GET /health', () => {
         it('mongo·redis·nats·temporal이 정상이면 200과 상태 정보를 반환한다', async () => {

--- a/apps/api/src/__tests__/helpers/create-app-test-context.ts
+++ b/apps/api/src/__tests__/helpers/create-app-test-context.ts
@@ -5,14 +5,24 @@ import {
     type HttpTestContext,
     type ModuleMetadataEx
 } from '@mannercode/testing'
+import { getConnectionToken } from '@nestjs/mongoose'
 import { SchedulerRegistry } from '@nestjs/schedule'
 import compression from 'compression'
-import { AppConfigService } from 'config'
+import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
 import express from 'express'
+import { getSharedTestMongooseConnection } from '../../../scripts'
 import { AppModule } from '../../app.module'
 
 export async function createAppTestContext(metadata: ModuleMetadataEx = {}) {
     const imports = [AppModule, ...(metadata.imports ?? [])]
+    const sharedMongo = getSharedTestMongooseConnection()
+    const overrideProviders = [
+        {
+            original: getConnectionToken(MONGO_CONNECTION_NAME),
+            replacement: sharedMongo.connection
+        },
+        ...(metadata.overrideProviders ?? [])
+    ]
 
     const ctx = await createHttpTestContext({
         configureApp: async (app) => {
@@ -27,12 +37,23 @@ export async function createAppTestContext(metadata: ModuleMetadataEx = {}) {
             }
         },
         ...metadata,
-        imports
+        imports,
+        overrideProviders
     })
 
-    await stopAllCronJobs(ctx)
+    try {
+        await stopAllCronJobs(ctx)
+    } catch (setupError) {
+        try {
+            await ctx.close()
+        } catch {
+            // 설정 오류가 정리 오류에 가려지지 않게 원래 오류를 유지한다.
+        }
 
-    // 연결 정리는 각 모듈의 ConnectionRegistry가 onModuleDestroy에서 책임지므로 close만 부른다.
+        throw setupError
+    }
+
+    // 앱별 자원과 모델은 close에서 정리하고, 파일이 공유하는 MongoClient는 Jest afterAll에서 닫는다.
     const teardown = async () => {
         await ctx.close()
     }

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -1,4 +1,5 @@
 export * from './app-config.service'
 export * from './connections'
+export * from './mongo-driver-options'
 export * from './mongoose-schema-options'
 export * from './project-id'

--- a/apps/api/src/config/mongo-driver-options.ts
+++ b/apps/api/src/config/mongo-driver-options.ts
@@ -1,0 +1,12 @@
+import type { MongoClientOptions } from 'mongodb'
+
+export function createMongoDriverOptions({ appName }: { appName?: string }): MongoClientOptions {
+    return {
+        appName,
+        // replica-set 서버마다 만들어지는 풀의 운영 부하 설정이다. Jest에서는 client를 테스트 파일 안에서 재사용한다.
+        minPoolSize: 50,
+        maxPoolSize: 200,
+        waitQueueTimeoutMS: 5000,
+        writeConcern: { journal: true, w: 'majority', wtimeoutMS: 5000 }
+    }
+}

--- a/apps/api/src/modules/mongoose-setup.module.ts
+++ b/apps/api/src/modules/mongoose-setup.module.ts
@@ -1,6 +1,376 @@
+import type { MongoClient, MongoClientEvents } from 'mongodb'
+import type { Connection } from 'mongoose'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
+import { AppConfigService, createMongoDriverOptions, MONGO_CONNECTION_NAME } from 'config'
+
+type ConnectionId = number | string
+type MongoClientEvent<EventName extends keyof MongoClientEvents> = Parameters<
+    MongoClientEvents[EventName]
+>[0]
+type PoolOptions = {
+    maxConnecting: number
+    maxIdleTimeMS: number
+    maxPoolSize: number
+    minPoolSize: number
+    waitQueueTimeoutMS: number
+}
+type PoolState = {
+    available: Set<ConnectionId>
+    checkedOut: Set<ConnectionId>
+    checkoutFailed: number
+    checkoutFailuresByReason: Record<string, number>
+    checkoutStarted: number
+    checkoutSucceeded: number
+    closedByReason: Record<string, number>
+    connecting: Set<ConnectionId>
+    connectionReadyDurationMaxMS: number
+    connectionsCreated: number
+    connectionsInvalidatedByClear: number
+    connectionsReady: number
+    diagnosticSuppressed: number
+    heartbeatFailed: number
+    heartbeatSucceeded: number
+    lastHeartbeatDurationMS: number
+    lastServerDescription?: Record<string, unknown>
+    maxCheckedOut: number
+    maxCheckoutDurationMS: number
+    maxHeartbeatDurationMS: number
+    poolClears: number
+    poolClosed: boolean
+    poolOptions?: PoolOptions
+    poolReady: boolean
+    startedAt: number
+}
+
+const newPoolState = (): PoolState => ({
+    available: new Set(),
+    checkedOut: new Set(),
+    checkoutFailed: 0,
+    checkoutFailuresByReason: {},
+    checkoutStarted: 0,
+    checkoutSucceeded: 0,
+    closedByReason: {},
+    connecting: new Set(),
+    connectionReadyDurationMaxMS: 0,
+    connectionsCreated: 0,
+    connectionsInvalidatedByClear: 0,
+    connectionsReady: 0,
+    diagnosticSuppressed: 0,
+    heartbeatFailed: 0,
+    heartbeatSucceeded: 0,
+    lastHeartbeatDurationMS: 0,
+    maxCheckedOut: 0,
+    maxCheckoutDurationMS: 0,
+    maxHeartbeatDurationMS: 0,
+    poolClears: 0,
+    poolClosed: false,
+    poolReady: false,
+    startedAt: Date.now()
+})
+
+export function registerMongoClientDiagnostics(
+    client: MongoClient,
+    dbName: string,
+    appName: string
+) {
+    const diagnosticClient = client as typeof client & {
+        __nestSeedMongoDiagnosticsRegistered?: boolean
+    }
+    if (diagnosticClient.__nestSeedMongoDiagnosticsRegistered) return
+    Object.defineProperty(diagnosticClient, '__nestSeedMongoDiagnosticsRegistered', {
+        configurable: true,
+        value: true
+    })
+
+    const pools = new Map<string, PoolState>()
+    const lastDiagnosticAt = new Map<string, number>()
+    let topology: Record<string, unknown> | undefined
+
+    const on = <EventName extends keyof MongoClientEvents>(
+        eventName: EventName,
+        listener: (event: MongoClientEvent<EventName>) => void
+    ) => {
+        const safeListener = ((event: MongoClientEvent<EventName>) => {
+            try {
+                listener(event)
+            } catch {
+                // Diagnostics must never affect the MongoDB operation that emitted the event.
+            }
+        }) as MongoClientEvents[EventName]
+        client.on(eventName, safeListener)
+    }
+
+    const getPool = (address: string) => {
+        let state = pools.get(address)
+        if (!state) {
+            state = newPoolState()
+            pools.set(address, state)
+        }
+        return state
+    }
+
+    const diagnosticText = (value: unknown) => {
+        if (value == null) return undefined
+        if (typeof value === 'string') {
+            return value.replace(/(mongodb(?:\+srv)?:\/\/)[^\s]+/giu, '$1<redacted>')
+        }
+        if (typeof value === 'bigint' || typeof value === 'number' || typeof value === 'boolean')
+            return value.toString()
+        if (typeof value === 'symbol') return value.description ?? 'symbol'
+        if (typeof value === 'function') return value.name ? `[function ${value.name}]` : 'function'
+        return undefined
+    }
+
+    const errorDetails = (error: unknown) => {
+        if (error == null) return undefined
+        if (typeof error !== 'object') return { message: diagnosticText(error) }
+        const record = error as Record<string, unknown>
+        return {
+            code: diagnosticText(record.code),
+            codeName: diagnosticText(record.codeName),
+            errorLabels: Array.isArray(record.errorLabels)
+                ? record.errorLabels.map(diagnosticText).filter((label) => label != null)
+                : undefined,
+            message: diagnosticText(record.message),
+            name: diagnosticText(record.name)
+        }
+    }
+
+    const logDiagnostic = (
+        kind: string,
+        address: string,
+        event: Record<string, unknown>,
+        state = getPool(address)
+    ) => {
+        const now = Date.now()
+        const reason = typeof event.reason === 'string' ? event.reason : ''
+        const key = `${kind}:${address}:${reason}`
+        const previous = lastDiagnosticAt.get(key) ?? 0
+        if (now - previous < 1000) {
+            state.diagnosticSuppressed += 1
+            return
+        }
+        lastDiagnosticAt.set(key, now)
+
+        const payload = {
+            address,
+            context: {
+                appName,
+                contextId: `${appName}:${process.env.PROJECT_ID ?? 'no-project'}`,
+                dbName,
+                pid: process.pid,
+                workerId: process.env.JEST_WORKER_ID
+            },
+            event,
+            kind,
+            pool: {
+                availableConnections: state.available.size,
+                checkedOutConnectionIds: [...state.checkedOut].slice(0, 20),
+                checkedOutConnections: state.checkedOut.size,
+                checkoutFailed: state.checkoutFailed,
+                checkoutFailuresByReason: state.checkoutFailuresByReason,
+                checkoutStarted: state.checkoutStarted,
+                checkoutSucceeded: state.checkoutSucceeded,
+                closedByReason: state.closedByReason,
+                connectingConnections: state.connecting.size,
+                connectionReadyDurationMaxMS: state.connectionReadyDurationMaxMS,
+                connectionsCreated: state.connectionsCreated,
+                connectionsInvalidatedByClear: state.connectionsInvalidatedByClear,
+                connectionsReady: state.connectionsReady,
+                diagnosticSuppressedSincePrevious: state.diagnosticSuppressed,
+                heartbeatFailed: state.heartbeatFailed,
+                heartbeatSucceeded: state.heartbeatSucceeded,
+                lastHeartbeatDurationMS: state.lastHeartbeatDurationMS,
+                lastServerDescription: state.lastServerDescription,
+                maxCheckedOutConnections: state.maxCheckedOut,
+                maxCheckoutDurationMS: state.maxCheckoutDurationMS,
+                maxHeartbeatDurationMS: state.maxHeartbeatDurationMS,
+                poolClears: state.poolClears,
+                poolClosed: state.poolClosed,
+                poolOptions: state.poolOptions,
+                poolReady: state.poolReady,
+                uptimeMS: now - state.startedAt,
+                waitersApprox: Math.max(
+                    0,
+                    state.checkoutStarted - state.checkoutSucceeded - state.checkoutFailed
+                )
+            },
+            time: new Date(now).toISOString(),
+            topology
+        }
+        state.diagnosticSuppressed = 0
+        process.stderr.write(`[mongo-client-diagnostics] ${JSON.stringify(payload)}\n`)
+    }
+
+    on('connectionPoolCreated', (event: { address: string; options: PoolOptions }) => {
+        getPool(event.address).poolOptions = event.options
+    })
+    on('connectionPoolReady', (event: { address: string }) => {
+        getPool(event.address).poolReady = true
+    })
+    on('connectionCreated', (event: { address: string; connectionId: ConnectionId }) => {
+        const state = getPool(event.address)
+        state.connectionsCreated += 1
+        state.connecting.add(event.connectionId)
+    })
+    on(
+        'connectionReady',
+        (event: { address: string; connectionId: ConnectionId; durationMS: number }) => {
+            const state = getPool(event.address)
+            state.connectionsReady += 1
+            state.connecting.delete(event.connectionId)
+            state.available.add(event.connectionId)
+            state.connectionReadyDurationMaxMS = Math.max(
+                state.connectionReadyDurationMaxMS,
+                event.durationMS
+            )
+        }
+    )
+    on('connectionCheckOutStarted', (event: { address: string }) => {
+        getPool(event.address).checkoutStarted += 1
+    })
+    on(
+        'connectionCheckedOut',
+        (event: { address: string; connectionId: ConnectionId; durationMS: number }) => {
+            const state = getPool(event.address)
+            state.checkoutSucceeded += 1
+            state.available.delete(event.connectionId)
+            state.checkedOut.add(event.connectionId)
+            state.maxCheckedOut = Math.max(state.maxCheckedOut, state.checkedOut.size)
+            state.maxCheckoutDurationMS = Math.max(state.maxCheckoutDurationMS, event.durationMS)
+        }
+    )
+    on('connectionCheckedIn', (event: { address: string; connectionId: ConnectionId }) => {
+        const state = getPool(event.address)
+        state.checkedOut.delete(event.connectionId)
+        state.available.add(event.connectionId)
+    })
+    on(
+        'connectionCheckOutFailed',
+        (event: { address: string; durationMS: number; error?: unknown; reason: string }) => {
+            const state = getPool(event.address)
+            state.checkoutFailed += 1
+            state.checkoutFailuresByReason[event.reason] =
+                (state.checkoutFailuresByReason[event.reason] ?? 0) + 1
+            logDiagnostic(
+                'connectionCheckOutFailed',
+                event.address,
+                {
+                    durationMS: event.durationMS,
+                    error: errorDetails(event.error),
+                    reason: event.reason
+                },
+                state
+            )
+        }
+    )
+    on(
+        'connectionClosed',
+        (event: { address: string; connectionId: ConnectionId; reason: string }) => {
+            const state = getPool(event.address)
+            state.connecting.delete(event.connectionId)
+            state.available.delete(event.connectionId)
+            state.checkedOut.delete(event.connectionId)
+            state.closedByReason[event.reason] = (state.closedByReason[event.reason] ?? 0) + 1
+        }
+    )
+    on(
+        'connectionPoolCleared',
+        (event: {
+            address: string
+            interruptInUseConnections?: boolean
+            serviceId?: { toString(): string }
+        }) => {
+            const state = getPool(event.address)
+            state.poolClears += 1
+            state.poolReady = false
+            state.connectionsInvalidatedByClear +=
+                state.available.size + state.checkedOut.size + state.connecting.size
+            state.available.clear()
+            state.connecting.clear()
+            logDiagnostic(
+                'connectionPoolCleared',
+                event.address,
+                {
+                    interruptInUseConnections: event.interruptInUseConnections,
+                    serviceId: event.serviceId?.toString()
+                },
+                state
+            )
+        }
+    )
+    on('connectionPoolClosed', (event: { address: string }) => {
+        const state = getPool(event.address)
+        state.poolClosed = true
+        state.poolReady = false
+        state.available.clear()
+        state.connecting.clear()
+        if (
+            state.checkedOut.size > 0 ||
+            state.checkoutStarted > state.checkoutSucceeded + state.checkoutFailed
+        ) {
+            logDiagnostic('connectionPoolClosedWithOutstandingWork', event.address, {}, state)
+        }
+        pools.delete(event.address)
+    })
+    on('serverHeartbeatSucceeded', (event: { connectionId: string; duration: number }) => {
+        const state = getPool(event.connectionId)
+        state.heartbeatSucceeded += 1
+        state.lastHeartbeatDurationMS = event.duration
+        state.maxHeartbeatDurationMS = Math.max(state.maxHeartbeatDurationMS, event.duration)
+    })
+    on(
+        'serverHeartbeatFailed',
+        (event: { connectionId: string; duration: number; failure: unknown }) => {
+            const state = getPool(event.connectionId)
+            state.heartbeatFailed += 1
+            state.lastHeartbeatDurationMS = event.duration
+            state.maxHeartbeatDurationMS = Math.max(state.maxHeartbeatDurationMS, event.duration)
+            logDiagnostic(
+                'serverHeartbeatFailed',
+                event.connectionId,
+                { durationMS: event.duration, error: errorDetails(event.failure) },
+                state
+            )
+        }
+    )
+    on(
+        'serverDescriptionChanged',
+        (event: {
+            address: string
+            newDescription: { error?: unknown; roundTripTime?: number; type: string }
+            previousDescription: { type: string }
+        }) => {
+            getPool(event.address).lastServerDescription = {
+                error: errorDetails(event.newDescription.error),
+                newType: event.newDescription.type,
+                previousType: event.previousDescription.type,
+                roundTripTimeMS: event.newDescription.roundTripTime
+            }
+        }
+    )
+    on(
+        'topologyDescriptionChanged',
+        (event: {
+            newDescription: {
+                servers: Map<string, { error?: unknown; type: string }>
+                setName?: string | null
+                type: string
+            }
+        }) => {
+            topology = {
+                servers: [...event.newDescription.servers].map(([address, description]) => ({
+                    address,
+                    error: errorDetails(description.error),
+                    type: description.type
+                })),
+                setName: event.newDescription.setName,
+                type: event.newDescription.type
+            }
+        }
+    )
+}
 
 @Module({
     imports: [
@@ -9,20 +379,32 @@ import { AppConfigService, MONGO_CONNECTION_NAME } from 'config'
             inject: [AppConfigService],
             useFactory: async (config: AppConfigService) => {
                 const { uri, dbName } = config.mongo
+                const testDiagnostics = process.env.NODE_ENV === 'test'
+                const appName = `nest-seed-test-w${process.env.JEST_WORKER_ID ?? '0'}-p${process.pid}-${process.env.TEST_ID ?? 'startup'}`
 
                 return {
+                    ...createMongoDriverOptions({ appName: testDiagnostics ? appName : undefined }),
+                    ...(testDiagnostics
+                        ? {
+                              appName,
+                              onConnectionCreate: (connection: Connection) => {
+                                  try {
+                                      registerMongoClientDiagnostics(
+                                          connection.getClient(),
+                                          dbName,
+                                          appName
+                                      )
+                                  } catch {
+                                      // Test diagnostics are best effort and must not block application startup.
+                                  }
+                              }
+                          }
+                        : {}),
                     autoCreate: true,
                     autoIndex: true,
                     bufferCommands: true,
                     dbName,
-                    // 부하 테스트가 복제본 4개에 동시에 요청 500건을 보내면, 복제본 한 대가 125건을 받는다.
-                    // 최대 연결 수가 50이면 모자라서 일부 요청이 대기 시간 5초를 넘기고 `MongoWaitQueueTimeoutError`로 끝난다.
-                    // 200으로 두면 이 구간에서 대기가 거의 발생하지 않는다.
-                    minPoolSize: 50,
-                    maxPoolSize: 200,
-                    uri,
-                    waitQueueTimeoutMS: 5000,
-                    writeConcern: { journal: true, w: 'majority', wtimeoutMS: 5000 }
+                    uri
                 }
             }
         })

--- a/libs/common/src/mongoose/__tests__/repository-init.spec.ts
+++ b/libs/common/src/mongoose/__tests__/repository-init.spec.ts
@@ -1,0 +1,32 @@
+import type { Model } from 'mongoose'
+import { AppendOnlyRepository } from '../append-only.repository'
+import { CrudRepository } from '../crud.repository'
+
+type Sample = { name: string }
+
+class SampleCrudRepository extends CrudRepository<Sample> {
+    constructor(model: Model<Sample>) {
+        super(model, 10, 100)
+    }
+}
+
+class SampleAppendOnlyRepository extends AppendOnlyRepository<Sample> {}
+
+describe('repository initialization', () => {
+    it.each([
+        ['CrudRepository', (model: Model<Sample>) => new SampleCrudRepository(model)],
+        ['AppendOnlyRepository', (model: Model<Sample>) => new SampleAppendOnlyRepository(model)]
+    ])('%s는 Mongoose가 시작한 모델 초기화만 기다린다', async (_name, createRepository) => {
+        const init = jest.fn(async () => undefined)
+        const createCollection = jest.fn()
+        const createIndexes = jest.fn()
+        const model = { createCollection, createIndexes, init } as unknown as Model<Sample>
+        const repository = createRepository(model)
+
+        await repository.onModuleInit()
+
+        expect(init).toHaveBeenCalledTimes(1)
+        expect(createCollection).not.toHaveBeenCalled()
+        expect(createIndexes).not.toHaveBeenCalled()
+    })
+})

--- a/libs/common/src/mongoose/append-only.repository.ts
+++ b/libs/common/src/mongoose/append-only.repository.ts
@@ -6,9 +6,8 @@ export abstract class AppendOnlyRepository<Doc> implements OnModuleInit {
     constructor(protected readonly model: Model<Doc>) {}
 
     async onModuleInit() {
-        // 동시 첫 save의 createCollection 경합을 피하려고 미리 초기화한다.
-        await this.model.createCollection()
-        await this.model.createIndexes()
+        // 모델 생성 때 Mongoose가 시작한 컬렉션·인덱스 초기화를 재사용해 준비만 기다린다.
+        await this.model.init()
     }
 
     newDocument(): HydratedDocument<Doc> {

--- a/libs/common/src/mongoose/crud.repository.ts
+++ b/libs/common/src/mongoose/crud.repository.ts
@@ -181,9 +181,8 @@ export abstract class CrudRepository<Doc> implements OnModuleInit {
     }
 
     async onModuleInit() {
-        // 동시 첫 save의 createCollection 경합을 피하려고 미리 초기화한다.
-        await this.model.createCollection()
-        await this.model.createIndexes()
+        // 모델 생성 때 Mongoose가 시작한 컬렉션·인덱스 초기화를 재사용해 준비만 기다린다.
+        await this.model.init()
     }
 
     async saveMany(

--- a/libs/testing/src/__tests__/create-test-context-cleanup.spec.ts
+++ b/libs/testing/src/__tests__/create-test-context-cleanup.spec.ts
@@ -1,0 +1,68 @@
+import type { INestApplication } from '@nestjs/common'
+
+describe('test context setup cleanup', () => {
+    it('앱 초기화가 실패하면 모듈을 정리하고 원래 오류를 다시 던진다', async () => {
+        const setupError = new Error('app init failed')
+        const onModuleDestroy = jest.fn()
+
+        class InitFailureProvider {
+            onModuleInit() {
+                throw setupError
+            }
+
+            onModuleDestroy() {
+                onModuleDestroy()
+            }
+        }
+
+        const { createTestContext } = await import('../create-test-context')
+        const result = createTestContext({ providers: [InitFailureProvider] })
+
+        await expect(result).rejects.toBe(setupError)
+        expect(onModuleDestroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('HTTP URL 조회가 실패하면 열린 서버와 모듈을 정리하고 원래 오류를 다시 던진다', async () => {
+        const setupError = new Error('getUrl failed')
+        const onModuleDestroy = jest.fn()
+        let app: INestApplication | undefined
+
+        class LifecycleProvider {
+            onModuleDestroy() {
+                onModuleDestroy()
+            }
+        }
+
+        const { createHttpTestContext } = await import('../create-http-test-context')
+        const result = createHttpTestContext({
+            configureApp: async (createdApp) => {
+                app = createdApp
+                jest.spyOn(createdApp, 'getUrl').mockRejectedValue(setupError)
+            },
+            providers: [LifecycleProvider]
+        })
+
+        await expect(result).rejects.toBe(setupError)
+        expect(app?.getHttpServer().listening).toBe(false)
+        expect(onModuleDestroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('실패 정리도 실패하면 최초 설정 오류를 유지한다', async () => {
+        const setupError = new Error('app init failed')
+
+        class SetupAndCleanupFailureProvider {
+            onModuleInit() {
+                throw setupError
+            }
+
+            onModuleDestroy() {
+                throw new Error('app cleanup failed')
+            }
+        }
+
+        const { createTestContext } = await import('../create-test-context')
+        const result = createTestContext({ providers: [SetupAndCleanupFailureProvider] })
+
+        await expect(result).rejects.toBe(setupError)
+    })
+})

--- a/libs/testing/src/create-http-test-context.ts
+++ b/libs/testing/src/create-http-test-context.ts
@@ -6,8 +6,18 @@ export type HttpTestContext = TestContext & { httpClient: HttpTestClient }
 export async function createHttpTestContext(metadata: ModuleMetadataEx): Promise<HttpTestContext> {
     const ctx = await createTestContext(metadata)
 
-    await ctx.app.listen(0, '127.0.0.1')
+    try {
+        await ctx.app.listen(0, '127.0.0.1')
 
-    const httpClient = new HttpTestClient(await ctx.app.getUrl())
-    return { httpClient, ...ctx }
+        const httpClient = new HttpTestClient(await ctx.app.getUrl())
+        return { httpClient, ...ctx }
+    } catch (setupError) {
+        try {
+            await ctx.close()
+        } catch {
+            // 설정 오류가 정리 오류에 가려지지 않게 원래 오류를 유지한다.
+        }
+
+        throw setupError
+    }
 }

--- a/libs/testing/src/create-test-context.ts
+++ b/libs/testing/src/create-test-context.ts
@@ -12,7 +12,7 @@ import { isDebuggingEnabled } from './utils'
 export type ModuleMetadataEx = ModuleMetadata & {
     configureApp?: (app: INestApplication<Server>) => Promise<void>
     ignoreGuards?: Type<CanActivate>[]
-    overrideProviders?: { original: Type; replacement: any }[]
+    overrideProviders?: { original: string | symbol | Type; replacement: any }[]
 }
 
 export type TestContext = {
@@ -49,11 +49,21 @@ export async function createTestContext({
 
     app.useLogger(isDebuggingEnabled() ? console : false)
 
-    if (configureApp) {
-        await configureApp(app)
-    }
+    try {
+        if (configureApp) {
+            await configureApp(app)
+        }
 
-    await app.init()
+        await app.init()
+    } catch (setupError) {
+        try {
+            await app.close()
+        } catch {
+            // 설정 오류가 정리 오류에 가려지지 않게 원래 오류를 유지한다.
+        }
+
+        throw setupError
+    }
 
     const close = async () => {
         await app.close()

--- a/tools/jest-helpers/index.js
+++ b/tools/jest-helpers/index.js
@@ -74,7 +74,7 @@ function setupJestLifecycle({
     connectMongo, // (workerId) => Promise<{ client, dbName }>
     createS3Client, // () => S3Client
     bucketName, // (workerId) => string
-    afterMongoConnect, // 선택: (client) => Promise<void>
+    afterMongoConnect, // 선택: (client, dbName) => Promise<void>
     onBeforeEach // 선택: (testId) => void | Promise<void>
 }) {
     let mongoClient
@@ -88,7 +88,7 @@ function setupJestLifecycle({
         const m = await connectMongo(workerId)
         mongoClient = m.client
         dbName = m.dbName
-        if (afterMongoConnect) await afterMongoConnect(mongoClient)
+        if (afterMongoConnect) await afterMongoConnect(mongoClient, dbName)
 
         s3Client = createS3Client()
         bucket = bucketName(workerId)


### PR DESCRIPTION
## What

- reuse one MongoDB client per Jest test file instead of recreating production-sized pools for every app context
- await memoized Mongoose model initialization instead of issuing duplicate collection and index DDL
- close partially initialized Nest applications without masking the original setup error
- capture bounded and redacted MongoDB diagnostics on CI failures

## Why

The failing Actions runs exhausted MongoDB checkout and replication capacity through connection-pool churn and duplicate startup DDL. Increasing timeouts would only mask that lifecycle amplification.

## Verification

- API suite: 315/315 tests with 100% coverage, three full parallel runs
- common suite: 638/638 tests
- testing suite: 61/61 tests
- workspace lint and API production build
- DDL regression: health boot reduced from 24/34 to 12/17 create/createIndexes commands
- diagnostic wrappers preserve the original process exit code