### PR TITLE
build: constrain Dependabot to coordinated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 # registry에서 직접 설치하는 dependencies/devDependencies는 정확 고정한다.
 # peerDependencies의 호환 범위와 로컬 workspace 연결(`*`)은 예외이며, 고정 버전은 갱신 장치가 없으면 포크 시점부터 묵기 시작한다.
-# npm, GitHub Actions, Docker 이미지의 minor/patch를 주 1회 묶고 major는 수동 검토할 별도 PR로 받는다. 보안 취약점 PR은 주기와 무관하게 바로 열린다.
+# npm, GitHub Actions, Docker 이미지의 minor/patch만 주 1회 묶는다. major는 서로 맞물린
+# toolchain/runtime을 한 PR에서 올려야 하므로 routine version update 대상에서 제외한다.
+# `allow.update-types`는 security update에는 적용되지 않아 major 보안 수정 PR도 계속 열린다.
 # 올라온 PR은 기존 test-atoz 워크플로(pull_request 트리거)가 그대로 검증한다.
 version: 2
 updates:
@@ -8,35 +10,45 @@ updates:
       directory: '/'
       schedule:
           interval: weekly
+      allow:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
       groups:
           npm-minor-patch:
               patterns: ['*']
               update-types: ['minor', 'patch']
-      # dependabot은 선언된 범위와 무관하게 @types/node를 최신 메이저로 고쳐 쓴 PR을 올린다.
-      # 타입의 메이저는 런타임 Node 메이저(devcontainer 이미지)와 짝이라 어긋나면 빌드가 깨진다.
-      # 메이저 범프 제안을 막는다. 런타임 Node를 올릴 때 타입도 함께 올린다.
-      ignore:
-          - dependency-name: '@types/node'
-            update-types: ['version-update:semver-major']
     - package-ecosystem: github-actions
       directory: '/'
       schedule:
           interval: weekly
+      allow:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
       groups:
           actions-minor-patch:
               patterns: ['*']
               update-types: ['minor', 'patch']
-    # Docker updater는 Dockerfile의 첫 FROM만 안정적으로 갱신한다. apps/api의 외부
-    # runtime 이미지는 두 번째 stage라 자동화 대상에서 제외한다. Node PR에서는 runtime을
-    # 수동으로 같은 tag+digest로 맞춰야 하며, test:config의 3개 이미지 동일성 계약이 누락을 막는다.
+    # 세 Dockerfile의 첫 외부 FROM을 같은 Node 이미지로 유지한다. dependency-name 기준
+    # cross-directory grouping으로 tag+digest 갱신도 항상 하나의 PR에서 수행한다.
     - package-ecosystem: docker
       directories:
           - '/.devcontainer'
+          - '/apps/api'
           - '/deploy'
       schedule:
           interval: weekly
+      allow:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
       groups:
           docker-minor-patch:
+              group-by: dependency-name
               patterns: ['*']
               update-types: ['minor', 'patch']
     # Compose updater는 리터럴 image 참조만 갱신한다. .env.infra의 *_IMAGE 변수는
@@ -47,7 +59,13 @@ updates:
           - '/infra'
       schedule:
           interval: weekly
+      allow:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
       groups:
           compose-minor-patch:
+              group-by: dependency-name
               patterns: ['*']
               update-types: ['minor', 'patch']

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,10 @@
 ARG DEPS_TAG
+FROM node:24.19.0-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runtime-base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 FROM nest-seed-deps:${DEPS_TAG} AS build
 
 COPY tsconfig.json ./
@@ -14,11 +20,7 @@ RUN npm run build --workspace=apps/api
 # runtime 단계는 root `package.json`이 없으므로, 같은 명령을 거기서 실행하면 그래프를 해석하지 못해 404로 실패한다.
 RUN npm prune --omit=dev
 
-FROM node:24.19.0-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runtime
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+FROM runtime-base AS runtime
 WORKDIR /workspace/apps/api
 COPY --from=build /workspace/apps/api/package.json /workspace/apps/api/
 COPY --from=build /workspace/node_modules /workspace/node_modules

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -83,7 +83,7 @@ gh api -X PATCH repos/OWNER/REPO \
 
 ## 4. Dependabot과 보안 기능
 
-`.github/dependabot.yml`은 npm, GitHub Actions와 추적 가능한 Dockerfile/Compose 이미지 참조를 매주 확인한다. 다단계 Dockerfile의 두 번째 `FROM`과 `.env.infra` 변수로 간접 참조한 이미지는 자동 갱신 범위가 아니므로, PR에서 Node runtime 및 인프라 digest의 수동 동기화 계약도 확인한다. 파일이 있다고 다음 저장소 설정까지 자동으로 켜지는 것은 아니다.
+`.github/dependabot.yml`은 npm, GitHub Actions와 추적 가능한 Dockerfile/Compose 이미지 참조의 minor/patch를 매주 확인한다. 같은 이미지가 여러 디렉터리에 있으면 dependency name으로 묶어 한 PR에서 갱신한다. routine major update는 생성하지 않는다. TypeScript와 ESLint 생태계, Node 이미지와 OS 패키지처럼 함께 바뀌어야 하는 범위를 관리자가 한 PR에서 올려 AtoZ로 검증한다. 이 제한은 security update에는 적용되지 않으므로 major 보안 수정도 PR로 열리며 자동 머지하지 않는다. `.env.infra` 변수로 간접 참조한 digest는 자동 갱신 범위가 아니므로 인프라 이미지 갱신 시 수동으로 맞춘다. 파일이 있다고 다음 저장소 설정까지 자동으로 켜지는 것은 아니다.
 
 - Settings → Code security에서 Dependabot alerts와 Dependabot security updates를 활성화한다.
 - Automated security fixes를 활성화한다.

--- a/tools/__tests__/configuration-contract.test.mjs
+++ b/tools/__tests__/configuration-contract.test.mjs
@@ -239,10 +239,13 @@ test('container base and infrastructure image references are digest-pinned', asy
         'deploy/deps.Dockerfile'
     ]) {
         const contents = await read(dockerfile)
-        for (const [, image] of contents.matchAll(/^FROM\s+(\S+)/gm)) {
+        const stages = new Set()
+        for (const [, image, alias] of contents.matchAll(/^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/gim)) {
+            if (stages.has(image)) continue
             if (image.startsWith('nest-seed-deps:')) continue
             assert.match(image, /@sha256:[a-f0-9]{64}$/, `${dockerfile} base image must be pinned`)
             if (image.startsWith('node:')) nodeBaseImages.push(image)
+            if (alias) stages.add(alias)
         }
     }
     assert.equal(nodeBaseImages.length, 3)
@@ -322,15 +325,24 @@ test('Stability keeps 60 API repetitions within three timeout-safe jobs', async 
     )
 })
 
-test('Dependabot major updates are not automatically merged', async () => {
+test('Dependabot only proposes grouped routine updates and keeps major updates manual', async () => {
     const config = await read('.github/dependabot.yml')
     const workflow = await read('.github/workflows/dependabot-auto-merge.yaml')
 
-    assert.match(config, /update-types:\s*\['minor', 'patch'\]/)
+    const ecosystems = [...config.matchAll(/^\s+- package-ecosystem:/gm)]
+    const routineAllowLists = [
+        ...config.matchAll(
+            /allow:\s+- dependency-name: '\*'\s+update-types:\s+- version-update:semver-minor\s+- version-update:semver-patch/g
+        )
+    ]
+    assert.equal(ecosystems.length, 4)
+    assert.equal(routineAllowLists.length, ecosystems.length)
+    assert.equal(config.match(/update-types:\s*\['minor', 'patch'\]/g)?.length, ecosystems.length)
     assert.match(
         config,
-        /package-ecosystem: docker\s+directories:\s+- '\/\.devcontainer'\s+- '\/deploy'/
+        /package-ecosystem: docker\s+directories:\s+- '\/\.devcontainer'\s+- '\/apps\/api'\s+- '\/deploy'/
     )
+    assert.equal(config.match(/group-by: dependency-name/g)?.length, 2)
     assert.match(
         config,
         /package-ecosystem: docker-compose\s+directories:\s+- '\/deploy'\s+- '\/infra'/


### PR DESCRIPTION
## Summary
- allow routine Dependabot PRs only for minor and patch updates while preserving security update PRs
- group Docker updates by dependency across devcontainer, API runtime, and deployment dependency images
- make the API runtime Node image the first external Docker stage so Dependabot can update all Node consumers together
- enforce the update policy and image ownership contract in configuration tests

## Why
Independent major PRs for ESLint, TypeScript, and Node are invalid in this seed: they require coordinated plugin/compiler or OS-package changes. The previous configuration prevented auto-merge but still created permanently red PRs.

## Verification
- npm run test:config
- npm run lint
- actual apps/api Docker image build using the current dependency image