### PR TITLE
test: scope app resources without module resets

### DIFF
--- a/apps/api/src/__tests__/app.module.spec.ts
+++ b/apps/api/src/__tests__/app.module.spec.ts
@@ -1,8 +1,10 @@
 describe('AppModule', () => {
-    it('실제 AppModule 그래프에서 모든 모듈, 컨트롤러, 가드를 주입할 수 있다', async () => {
-        // `resetModules: true` 환경에서는 NestJS 내부 토큰(`ModuleRef` 등)이 두 실행 영역으로 갈라지지 않도록, 모든 모듈을 같은 그래프에서 동적으로 가져온다.
+    it('실제 AppModule 그래프가 현재 테스트의 PROJECT_ID로 모든 의존성을 만든다', async () => {
         const { createAppTestContext } = await import('./helpers')
+        const { AppConfigService } = await import('config')
         const ctx = await createAppTestContext()
+
+        expect(ctx.module.get(AppConfigService).projectId).toBe(process.env.PROJECT_ID)
 
         await ctx.close()
     })

--- a/apps/api/src/__tests__/application/purchase-events.spec.ts
+++ b/apps/api/src/__tests__/application/purchase-events.spec.ts
@@ -21,8 +21,6 @@ describe('PurchaseEvents', () => {
         fix = await createAppTestContext()
         teardown = fix.teardown
         events = fix.module.get(PurchaseEvents)
-        // `resetModules: true` 환경에서는 감시 대상 Logger가 구독자 Logger와 같은 실행 영역에 있어야 한다.
-        // 그래서 같은 모듈 그래프에서 동적으로 가져온다.
         const { Logger } = await import('@nestjs/common')
         logSpy = jest.spyOn(Logger.prototype, 'log')
     })

--- a/apps/api/src/__tests__/application/purchase.spec.ts
+++ b/apps/api/src/__tests__/application/purchase.spec.ts
@@ -153,8 +153,6 @@ describe('PurchaseService', () => {
                 // 티켓은 아직 전이 전이므로 되돌릴 것이 없다.
                 // 특정 메서드 호출을 직접 가로채지 않고 관측 가능한 로그를 기준으로 삼아, 테스트가 구현 세부에 지나치게 묶이지 않게 한다.
                 beforeEach(async () => {
-                    // `resetModules: true` 환경에서는 감시 대상 Logger가 운영 코드의 Logger와 같은 실행 영역에 있어야 한다.
-                    // 그래서 같은 모듈 그래프에서 동적으로 가져온다.
                     const { Logger } = await import('@nestjs/common')
                     jest.spyOn(Logger.prototype, 'log').mockImplementation((message: unknown) => {
                         if (message === 'completePurchase') {

--- a/apps/api/src/__tests__/helpers/override-config.ts
+++ b/apps/api/src/__tests__/helpers/override-config.ts
@@ -1,7 +1,6 @@
 import type { TestingModule } from '@nestjs/testing'
 import type { AppConfigService } from 'config'
 
-// resetModules 환경에서 같은 클래스 정체성을 쓰도록 AppConfigService는 동적으로 가져온다.
 export async function overrideConfigGetter<K extends 'asset' | 'ticket'>(
     module: Pick<TestingModule, 'get'>,
     key: K,

--- a/apps/api/src/config/app-config.service.ts
+++ b/apps/api/src/config/app-config.service.ts
@@ -1,7 +1,8 @@
 import { BaseConfigService } from '@mannercode/common'
-import { Injectable } from '@nestjs/common'
+import { Inject, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import Joi from 'joi'
+import { PROJECT_ID_TOKEN } from './project-id'
 
 @Injectable()
 export class AppConfigService extends BaseConfigService {
@@ -174,7 +175,10 @@ export class AppConfigService extends BaseConfigService {
     }
 
     // 명시하지 않으면 Nest가 부모 constructor의 주입 메타데이터를 읽지 못한다.
-    constructor(configService: ConfigService) {
+    constructor(
+        configService: ConfigService,
+        @Inject(PROJECT_ID_TOKEN) readonly projectId: string
+    ) {
         super(configService)
     }
 }

--- a/apps/api/src/config/project-id.ts
+++ b/apps/api/src/config/project-id.ts
@@ -1,7 +1,8 @@
 import { Require } from '@mannercode/common'
 
-// 모듈 데코레이터 평가 시점에는 DI가 아직 없어 환경 변수를 직접 읽어야 한다.
-export function getProjectId(): string {
+export const PROJECT_ID_TOKEN = Symbol('PROJECT_ID')
+
+export function readProjectId(): string {
     Require.defined(process.env.PROJECT_ID, 'PROJECT_ID must be defined.')
     return process.env.PROJECT_ID
 }

--- a/apps/api/src/modules/app-config.module.ts
+++ b/apps/api/src/modules/app-config.module.ts
@@ -1,6 +1,6 @@
 import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
-import { AppConfigService } from 'config'
+import { AppConfigService, PROJECT_ID_TOKEN, readProjectId } from 'config'
 import { MongooseSetupModule } from './mongoose-setup.module'
 import { NatsSetupModule } from './nats-setup.module'
 import { RedisSetupModule } from './redis-setup.module'
@@ -20,9 +20,10 @@ import { TemporalSetupModule } from './temporal-setup.module'
         NatsSetupModule,
         TemporalSetupModule
     ],
-    providers: [AppConfigService],
+    providers: [{ provide: PROJECT_ID_TOKEN, useFactory: readProjectId }, AppConfigService],
     exports: [
         AppConfigService,
+        PROJECT_ID_TOKEN,
         MongooseSetupModule,
         RedisSetupModule,
         NatsSetupModule,

--- a/apps/api/src/services/application/purchase/purchase.events.ts
+++ b/apps/api/src/services/application/purchase/purchase.events.ts
@@ -1,13 +1,18 @@
 import { InjectNatsPubSub, NatsPubSubService } from '@mannercode/common'
 import { Injectable } from '@nestjs/common'
-import { getProjectId } from 'config'
+import { AppConfigService } from 'config'
 
 // PROJECT_ID로 테스트 이벤트를 격리한다. 구독자가 queue를 지정하지 않으면 모든 복제본에 전달된다.
 @Injectable()
 export class PurchaseEvents {
-    readonly subjects = { purchased: `${getProjectId()}.purchase.ticketPurchased` }
+    readonly subjects: { purchased: string }
 
-    constructor(@InjectNatsPubSub() private readonly natsPubSub: NatsPubSubService) {}
+    constructor(
+        @InjectNatsPubSub() private readonly natsPubSub: NatsPubSubService,
+        config: AppConfigService
+    ) {
+        this.subjects = { purchased: `${config.projectId}.purchase.ticketPurchased` }
+    }
 
     async emitTicketPurchased(payload: TicketPurchasedEvent) {
         await this.natsPubSub.publish(this.subjects.purchased, JSON.stringify(payload))

--- a/apps/api/src/services/application/purchase/purchase.module.ts
+++ b/apps/api/src/services/application/purchase/purchase.module.ts
@@ -1,6 +1,6 @@
 import { CacheModule, NatsPubSubModule } from '@mannercode/common'
 import { Module } from '@nestjs/common'
-import { getProjectId, NATS_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
+import { AppConfigService, NATS_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
 import { PurchaseRecordsModule, ShowtimesModule, TicketHoldingModule, TicketsModule } from 'core'
 import { PaymentsModule } from 'infrastructure'
 import {
@@ -21,8 +21,9 @@ import { PurchaseService } from './purchase.service'
         PaymentsModule,
         NatsPubSubModule.register({ natsName: NATS_CONNECTION_NAME }),
         CacheModule.register({
+            inject: [AppConfigService],
             name: 'purchase',
-            prefix: `cache:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `cache:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME
         })
     ],

--- a/apps/api/src/services/application/showtime-creation/internal/showtime-creation-orchestrator.service.ts
+++ b/apps/api/src/services/application/showtime-creation/internal/showtime-creation-orchestrator.service.ts
@@ -5,7 +5,7 @@ import {
     WorkflowIdReusePolicy
 } from '@mannercode/common'
 import { Inject, Injectable, Logger } from '@nestjs/common'
-import { TEMPORAL_CLIENT_NAME } from 'config'
+import { AppConfigService, TEMPORAL_CLIENT_NAME } from 'config'
 import { BulkCreateShowtimesDto } from '../dtos'
 import { getShowtimeCreationTaskQueue } from '../showtime-creation-task-queue'
 import { ShowtimeCreationEvents } from '../showtime-creation.events'
@@ -17,7 +17,8 @@ export class ShowtimeCreationOrchestratorService {
 
     constructor(
         private readonly events: ShowtimeCreationEvents,
-        @Inject(getTemporalClientToken(TEMPORAL_CLIENT_NAME)) private readonly temporal: Client
+        @Inject(getTemporalClientToken(TEMPORAL_CLIENT_NAME)) private readonly temporal: Client,
+        private readonly config: AppConfigService
     ) {}
 
     async enqueueShowtimeCreationJob(createDto: BulkCreateShowtimesDto): Promise<string> {
@@ -29,7 +30,7 @@ export class ShowtimeCreationOrchestratorService {
         // 같은 ID로 두 번 시작하려는 요청은 `REJECT_DUPLICATE` 옵션이 막으므로 별도 중복 방지 키가 필요 없다.
         await this.temporal.workflow.start('showtimeCreationWorkflowV2', {
             args: [{ createDto, sagaId }],
-            taskQueue: getShowtimeCreationTaskQueue(),
+            taskQueue: getShowtimeCreationTaskQueue(this.config.projectId),
             workflowId: sagaId,
             workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
         })

--- a/apps/api/src/services/application/showtime-creation/showtime-creation-task-queue.ts
+++ b/apps/api/src/services/application/showtime-creation/showtime-creation-task-queue.ts
@@ -1,13 +1,11 @@
-import { getProjectId } from 'config'
-
 /**
  * 작업 큐 이름에 PROJECT_ID를 포함해 병렬 테스트 워커의 실행 공간을 분리한다.
  * 운영에서는 PROJECT_ID가 고정되어 큐 이름도 안정적으로 유지된다.
  */
-export function getLegacyShowtimeCreationTaskQueue() {
-    return `showtime-creation-${getProjectId()}`
+export function getLegacyShowtimeCreationTaskQueue(projectId: string) {
+    return `showtime-creation-${projectId}`
 }
 
-export function getShowtimeCreationTaskQueue() {
-    return `showtime-creation-v2-${getProjectId()}`
+export function getShowtimeCreationTaskQueue(projectId: string) {
+    return `showtime-creation-v2-${projectId}`
 }

--- a/apps/api/src/services/application/showtime-creation/showtime-creation.events.ts
+++ b/apps/api/src/services/application/showtime-creation/showtime-creation.events.ts
@@ -1,13 +1,13 @@
 import { InjectNatsPubSub, JsonUtil, NatsPubSubService } from '@mannercode/common'
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
-import { getProjectId } from 'config'
+import { AppConfigService } from 'config'
 import { Observable, Subject } from 'rxjs'
 import type { ShowtimeCreationEvent } from './internal/types'
 
 // NATS로 복제본을 건넌 상태를 로컬 RxJS 스트림에 전달하며, PROJECT_ID로 테스트를 격리한다.
 @Injectable()
 export class ShowtimeCreationEvents implements OnModuleInit, OnModuleDestroy {
-    private readonly natsSubject = `${getProjectId()}.showtime-creation.statusChanged`
+    private readonly natsSubject: string
 
     private readonly subject = new Subject<ShowtimeCreationEvent>()
     private readonly handler = (message: string) => {
@@ -15,7 +15,12 @@ export class ShowtimeCreationEvents implements OnModuleInit, OnModuleDestroy {
         this.subject.next(event)
     }
 
-    constructor(@InjectNatsPubSub() private readonly natsPubSub: NatsPubSubService) {}
+    constructor(
+        @InjectNatsPubSub() private readonly natsPubSub: NatsPubSubService,
+        config: AppConfigService
+    ) {
+        this.natsSubject = `${config.projectId}.showtime-creation.statusChanged`
+    }
 
     async onModuleInit() {
         await this.natsPubSub.subscribe(this.natsSubject, this.handler)

--- a/apps/api/src/services/application/showtime-creation/showtime-creation.module.ts
+++ b/apps/api/src/services/application/showtime-creation/showtime-creation.module.ts
@@ -3,7 +3,6 @@ import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 import {
     AppConfigService,
-    getProjectId,
     MONGO_CONNECTION_NAME,
     NATS_CONNECTION_NAME,
     REDIS_CONNECTION_NAME
@@ -37,8 +36,9 @@ const SHOWTIME_CREATION_WORKER = Symbol('SHOWTIME_CREATION_WORKER')
         // v2도 rolling migration 동안 v1 binary와 같은 lock key를 사용한다.
         // original Temporal queue가 완전히 drain된 뒤 별도 릴리스에서 제거할 수 있다.
         CacheModule.register({
+            inject: [AppConfigService],
             name: 'showtime-creation',
-            prefix: `cache:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `cache:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME
         }),
         MongooseModule.forFeature(
@@ -76,7 +76,7 @@ const SHOWTIME_CREATION_WORKER = Symbol('SHOWTIME_CREATION_WORKER')
                     maxConcurrentWorkflowTaskExecutions: 2,
                     maxConcurrentWorkflowTaskPolls: 2,
                     namespace: config.temporal.namespace,
-                    taskQueue: getLegacyShowtimeCreationTaskQueue(),
+                    taskQueue: getLegacyShowtimeCreationTaskQueue(config.projectId),
                     workflowBundlePath: legacyShowtimeCreationBundle.bundlePath
                 })
         },
@@ -88,7 +88,7 @@ const SHOWTIME_CREATION_WORKER = Symbol('SHOWTIME_CREATION_WORKER')
                     activities: activities.bind(),
                     address: config.temporal.address,
                     namespace: config.temporal.namespace,
-                    taskQueue: getShowtimeCreationTaskQueue(),
+                    taskQueue: getShowtimeCreationTaskQueue(config.projectId),
                     workflowBundlePath: showtimeCreationBundle.bundlePath
                 })
         }

--- a/apps/api/src/services/core/admins/admins.module.ts
+++ b/apps/api/src/services/core/admins/admins.module.ts
@@ -1,12 +1,7 @@
 import { AppLoggerService, JwtAuthModule, SecurityEvent, TimeUtil } from '@mannercode/common'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import {
-    AppConfigService,
-    getProjectId,
-    MONGO_CONNECTION_NAME,
-    REDIS_CONNECTION_NAME
-} from 'config'
+import { AppConfigService, MONGO_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
 import { AdminsRepository } from './admins.repository'
 import { AdminsService } from './admins.service'
 import { ADMIN_JWT_AUTH_NAME, AdminAuthenticationService } from './internal'
@@ -22,7 +17,7 @@ import { Admin, AdminSchema } from './models'
         JwtAuthModule.register({
             inject: [AppConfigService, AppLoggerService],
             name: ADMIN_JWT_AUTH_NAME,
-            prefix: `jwtauth:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `jwtauth:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME,
             useFactory: ({ adminAuth }: AppConfigService, logger: AppLoggerService) => ({
                 auth: {

--- a/apps/api/src/services/core/ticket-holding/ticket-holding.module.ts
+++ b/apps/api/src/services/core/ticket-holding/ticket-holding.module.ts
@@ -1,14 +1,15 @@
 import { CacheModule } from '@mannercode/common'
 import { Module } from '@nestjs/common'
-import { getProjectId, REDIS_CONNECTION_NAME } from 'config'
+import { AppConfigService, REDIS_CONNECTION_NAME } from 'config'
 import { TicketHoldingService } from './ticket-holding.service'
 
 @Module({
     exports: [TicketHoldingService],
     imports: [
         CacheModule.register({
+            inject: [AppConfigService],
             name: 'ticket-holding',
-            prefix: `cache:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `cache:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME
         })
     ],

--- a/apps/api/src/services/core/users/users.module.ts
+++ b/apps/api/src/services/core/users/users.module.ts
@@ -1,12 +1,7 @@
 import { AppLoggerService, JwtAuthModule, SecurityEvent, TimeUtil } from '@mannercode/common'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import {
-    AppConfigService,
-    getProjectId,
-    MONGO_CONNECTION_NAME,
-    REDIS_CONNECTION_NAME
-} from 'config'
+import { AppConfigService, MONGO_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
 import { UserAuthenticationService } from './internal'
 import { User, UserSchema } from './models'
 import { UsersRepository } from './users.repository'
@@ -18,7 +13,7 @@ import { UsersService } from './users.service'
         MongooseModule.forFeature([{ name: User.name, schema: UserSchema }], MONGO_CONNECTION_NAME),
         JwtAuthModule.register({
             inject: [AppConfigService, AppLoggerService],
-            prefix: `jwtauth:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `jwtauth:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME,
             useFactory: ({ auth }: AppConfigService, logger: AppLoggerService) => ({
                 auth: {

--- a/apps/api/src/services/gateway/login-rate-limiter.service.ts
+++ b/apps/api/src/services/gateway/login-rate-limiter.service.ts
@@ -1,6 +1,6 @@
 import { getRedisConnectionToken, TimeUtil, type RedisConnection } from '@mannercode/common'
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common'
-import { AppConfigService, getProjectId, REDIS_CONNECTION_NAME } from 'config'
+import { AppConfigService, REDIS_CONNECTION_NAME } from 'config'
 import { createHash } from 'node:crypto'
 import { AuthErrors } from './guards'
 
@@ -19,7 +19,7 @@ export class LoginRateLimiterService {
     private readonly accountFailureLimit: number
     private readonly failureWindowMs: number
     private readonly ipFailureLimit: number
-    private readonly prefix = `login-rate-limit:${getProjectId()}`
+    private readonly prefix: string
 
     constructor(
         @Inject(getRedisConnectionToken(REDIS_CONNECTION_NAME))
@@ -29,6 +29,7 @@ export class LoginRateLimiterService {
         this.accountFailureLimit = config.loginRateLimit.accountFailureLimit
         this.failureWindowMs = TimeUtil.toMs(config.loginRateLimit.failureWindow)
         this.ipFailureLimit = config.loginRateLimit.ipFailureLimit
+        this.prefix = `login-rate-limit:${config.projectId}`
     }
 
     async assertAllowed(role: LoginRole, email: string, ip: string): Promise<void> {

--- a/apps/api/src/services/infrastructure/assets/assets.module.ts
+++ b/apps/api/src/services/infrastructure/assets/assets.module.ts
@@ -1,12 +1,7 @@
 import { CacheModule, S3ObjectModule } from '@mannercode/common'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import {
-    AppConfigService,
-    getProjectId,
-    MONGO_CONNECTION_NAME,
-    REDIS_CONNECTION_NAME
-} from 'config'
+import { AppConfigService, MONGO_CONNECTION_NAME, REDIS_CONNECTION_NAME } from 'config'
 import { AssetsRepository } from './assets.repository'
 import { AssetsService } from './assets.service'
 import { Asset, AssetSchema } from './models'
@@ -23,8 +18,9 @@ import { Asset, AssetSchema } from './models'
             useFactory: (config: AppConfigService) => config.s3
         }),
         CacheModule.register({
+            inject: [AppConfigService],
             name: 'assets',
-            prefix: `cache:${getProjectId()}`,
+            prefix: (config: AppConfigService) => `cache:${config.projectId}`,
             redisName: REDIS_CONNECTION_NAME
         })
     ],

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -528,24 +528,21 @@ describe('PATCH /theaters/:id', () => {
 })
 ```
 
-### 동적 가져오기 — 왜 필요한가
+### 테스트별 자원 격리
 
 각 테스트가 다른 테스트와 부딪히지 않도록, `jest.config`가 Jest 명령마다 고유한 실행 ID를 만든다. `jest.setup`은 app 모듈을 읽기 전에 먼저 실행 ID와 worker 번호가 들어간 startup `PROJECT_ID`를 설정하고, `beforeEach`에서 테스트별 `TEST_ID` suffix로 다시 갱신한다. Redis/cache prefix, NATS subject, Temporal task queue 이름이 이 값을 따라 갈라진다. MongoDB 데이터베이스와 S3 버킷도 실행 ID와 Jest worker 번호를 조합해 만든다. coverage·로그·Temporal workflow bundle은 `_output/jest-runs/<실행 ID>/` 아래에서 실행별로 분리된다. 따라서 같은 devcontainer에서 API Jest 명령을 동시에 실행해도 같은 번호의 worker나 파일 산출물을 공유하지 않는다.
 
-문제는 일반적인 가져오기 방식이다. 파일 맨 위에 `import { createUsersFixture } from './users.fixture'`라고 쓰면, 그 모듈은 처음 한 번만 평가된다. 모듈이 처음 평가될 때 읽은 `process.env.PROJECT_ID`나 `process.env.TEST_ID`로 cache prefix, NATS subject, Temporal queue 같은 값이 만들어진다. 그래서 다음 테스트도 이전 테스트의 값을 그대로 쓰게 된다.
+Nest 모듈 파일은 프로세스에서 한 번만 평가된다. 따라서 데코레이터 인자에서 `process.env.PROJECT_ID`를 읽으면 첫 테스트의 값에 고정된다. cache와 JWT 모듈은 정적인 값을 캡처하지 않고, 제공자를 만들 때 `AppConfigService.projectId`를 주입받아 prefix를 계산한다. NATS subject와 Temporal queue도 서비스나 worker를 생성할 때 같은 설정값으로 만든다.
 
-이 문제를 피하려고 Jest 설정에 `resetModules: true`를 켠다. 그리고 픽스처는 **`beforeEach` 안에서 `await import`로 동적으로 가져온다**. 이렇게 하면 테스트마다 모듈이 새로 평가되고, 그 시점의 `TEST_ID`와 `PROJECT_ID`가 픽스처와 앱 모듈에 반영된다.
-
-IDE 자동 완성과 타입 체크는 유지하고 싶다. 그래서 타입은 `import type`으로 정적으로 가져온다. 타입 가져오기는 런타임 코드를 만들지 않는다.
+이 구조에서는 Jest 모듈 레지스트리를 테스트마다 초기화할 필요가 없다. 애플리케이션 코드와 Nest/Temporal 의존성은 worker 안에서 한 번 로드되고, 테스트별 애플리케이션 컨텍스트만 새로 만든다. 픽스처는 정적으로 가져와도 자원 격리가 유지된다.
 
 ```ts
-import type { AppTestContext } from '../helpers' // 타입만 가져오므로 런타임 영향 없음
+import { createAppTestContext, type AppTestContext } from '../helpers'
 
 describe('Users', () => {
     let fix: AppTestContext
 
     beforeEach(async () => {
-        const { createAppTestContext } = await import('../helpers')
         fix = await createAppTestContext()
     })
 })

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,7 +3,6 @@ module.exports = {
     testEnvironment: 'node',
     resetMocks: true,
     restoreMocks: true,
-    resetModules: true,
     // worker 재시작이 메모리 누수를 가리지 않도록 idle memory limit은 두지 않는다.
     coverageReporters: ['lcov', 'text'],
     coverageThreshold: { global: { branches: 100, functions: 100, lines: 100, statements: 100 } },

--- a/libs/common/src/auth/__tests__/jwt-auth.service.fixture.ts
+++ b/libs/common/src/auth/__tests__/jwt-auth.service.fixture.ts
@@ -29,7 +29,7 @@ export async function createJwtAuthServiceFixture() {
         imports: [
             RedisModule.forRoot({ type: 'single', url: process.env.TESTLIB_REDIS_URL }),
             JwtAuthModule.register({
-                prefix: withTestId('jwt-auth'),
+                prefix: async () => withTestId('jwt-auth'),
                 useFactory() {
                     return {
                         auth: {

--- a/libs/common/src/auth/jwt-auth.module.ts
+++ b/libs/common/src/auth/jwt-auth.module.ts
@@ -23,12 +23,13 @@ export class JwtAuthModule {
             useFactory: async (jwtService: JwtService, redis: Redis, ...args: any[]) => {
                 const factoryOptions = await useFactory(...args)
                 const { auth, onEvent, userIdField } = factoryOptions
+                const resolvedPrefix = typeof prefix === 'function' ? await prefix(...args) : prefix
 
                 return new JwtAuthService(
                     jwtService,
                     auth,
                     redis,
-                    `${prefix}:${defaultTo(name, 'default')}`,
+                    `${resolvedPrefix}:${defaultTo(name, 'default')}`,
                     defaultTo(userIdField, DEFAULT_USER_ID_FIELD),
                     onEvent
                 )

--- a/libs/common/src/auth/jwt-auth.types.ts
+++ b/libs/common/src/auth/jwt-auth.types.ts
@@ -68,7 +68,7 @@ export type JwtAuthFactoryOptions = {
 export type JwtAuthModuleOptions = {
     inject?: any[]
     name?: string
-    prefix: string
+    prefix: string | ((...args: any[]) => Promise<string> | string)
     redisName?: string
     useFactory: (...args: any[]) => JwtAuthFactoryOptions | Promise<JwtAuthFactoryOptions>
 }

--- a/libs/common/src/cache/__tests__/cache.service.fixture.ts
+++ b/libs/common/src/cache/__tests__/cache.service.fixture.ts
@@ -23,7 +23,7 @@ export async function createCacheServiceFixture() {
         imports: [
             RedisModule.forRoot({ type: 'single', url: process.env.TESTLIB_REDIS_URL }, 'name'),
             CacheModule.register({ prefix, redisName: 'name' }),
-            CacheModule.register({ name: 'a', prefix, redisName: 'name' }),
+            CacheModule.register({ name: 'a', prefix: async () => prefix, redisName: 'name' }),
             CacheModule.register({ name: 'b', prefix, redisName: 'name' })
         ],
         providers: [TestInjectCacheService]

--- a/libs/common/src/cache/cache.module.ts
+++ b/libs/common/src/cache/cache.module.ts
@@ -12,13 +12,15 @@ export function InjectCache(name?: string): ParameterDecorator {
 @Module({})
 export class CacheModule {
     static register(options: CacheModuleOptions): DynamicModule {
-        const { name, prefix, redisName } = options
+        const { inject, name, prefix, redisName } = options
 
         const provider = {
-            inject: [getRedisConnectionToken(redisName)],
+            inject: [getRedisConnectionToken(redisName), ...defaultTo(inject, [])],
             provide: CacheService.getName(name),
-            useFactory: async (redis: Redis) =>
-                new CacheService(redis, `${prefix}:${defaultTo(name, 'default')}`)
+            useFactory: async (redis: Redis, ...args: any[]) => {
+                const resolvedPrefix = typeof prefix === 'function' ? await prefix(...args) : prefix
+                return new CacheService(redis, `${resolvedPrefix}:${defaultTo(name, 'default')}`)
+            }
         }
 
         return { exports: [provider], module: CacheModule, providers: [provider] }

--- a/libs/common/src/cache/cache.types.ts
+++ b/libs/common/src/cache/cache.types.ts
@@ -1,1 +1,6 @@
-export type CacheModuleOptions = { name?: string; prefix: string; redisName?: string }
+export type CacheModuleOptions = {
+    inject?: any[]
+    name?: string
+    prefix: string | ((...args: any[]) => Promise<string> | string)
+    redisName?: string
+}

--- a/libs/common/src/temporal/__tests__/temporal-integration.spec.ts
+++ b/libs/common/src/temporal/__tests__/temporal-integration.spec.ts
@@ -7,7 +7,7 @@ import type { TemporalClientConfig } from '../temporal.types'
 
 /**
  * 이 파일 전체가 공유하는 단일 Connection과 Client이다.
- * 각 `it` 안의 `await import`(프로젝트 컨벤션: resetModules: true)는 SUT 모듈에 새로운 클래스 정체성을 부여하고, 살아 있는 인프라 핸들만 재사용한다.
+ * 각 `it` 안의 `await import`는 무거운 Temporal 테스트 환경을 파일 수준에서 준비한 뒤 SUT를 늦게 읽게 한다.
  */
 let connection: Connection
 let client: Client

--- a/libs/testing/jest.config.js
+++ b/libs/testing/jest.config.js
@@ -10,6 +10,8 @@ const tsJestPreset = createDefaultPreset({ tsconfig: tsconfigPath })
 module.exports = {
     ...baseConfig,
     ...tsJestPreset,
+    // 이 패키지는 Jest resetModules 동작 자체를 계약 테스트한다. 애플리케이션 모듈 격리에는 사용하지 않는다.
+    resetModules: true,
     // 이 워크스페이스 test 스크립트는 의도적으로 --coverage를 붙이지 않는다.
     // 헬퍼 대부분이 libs/common 사용자 코드를 통해 간접 검증되기 때문이다.
     roots: ['<rootDir>/src']


### PR DESCRIPTION
## What changed
- capture `PROJECT_ID` once per Nest application context through a dedicated DI token
- resolve cache and JWT prefixes from injected configuration when providers are created
- derive NATS subjects and Temporal task queues from the same context-scoped project ID
- remove global Jest `resetModules`; retain it only in the package that explicitly tests Jest reset behavior
- add regression coverage for context-scoped project IDs and async prefix factories

## Root cause
Global `resetModules` reloaded the full Nest and Temporal dependency graph before every test. Workers accumulated multi-gigabyte heaps and could not finish graceful shutdown within Jest limits; reducing worker count only concentrated more work into each worker and caused ARM OOM failures.

Application resource names previously read `PROJECT_ID` during module evaluation, which forced that reset strategy. Resource scoping now happens at application-context/provider creation, so each test stays isolated without rebuilding the module registry.

## Verification
- API with coverage: 36 suites, 388 tests, 100% coverage; no OOM or forced-exit warning
- API without coverage: 36 suites, 388 tests; no OOM or forced-exit warning
- common: 44 suites, 654 tests, 100% coverage
- testing: 11 suites, 61 tests
- temporal-sandbox: 1 suite, 7 tests, 100% coverage
- parallel API Jest isolation contracts: 8 tests
- all workspace lint, typecheck, formatting, docs links, and config contracts pass