### PR TITLE
fix(security): remove insecure randomness and reflected output

### DIFF
--- a/libs/common/src/cache/cache.service.ts
+++ b/libs/common/src/cache/cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import Redis from 'ioredis'
+import { randomUUID } from 'node:crypto'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { defaultTo } from '../utils'
 
@@ -62,7 +63,7 @@ export class CacheService {
     ): Promise<{ ran: false } | { ran: true; result: T }> {
         if (ttlMs <= 0) throw new Error('Lock TTL must be a positive integer (ms)')
 
-        const token = `${process.pid}:${Date.now()}:${Math.random()}`
+        const token = `${process.pid}:${Date.now()}:${randomUUID()}`
         const lockKey = this.getKey(`lock:${key}`)
         const acquired = await this.redis.set(lockKey, token, 'PX', ttlMs, 'NX')
 

--- a/libs/testing/src/__tests__/http.test-client.fixture.ts
+++ b/libs/testing/src/__tests__/http.test-client.fixture.ts
@@ -1,5 +1,16 @@
 import type { Request, Response } from 'express'
-import { Body, Controller, Get, Header, Headers, Post, Req, Res, Sse } from '@nestjs/common'
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    Header,
+    Headers,
+    Post,
+    Req,
+    Res,
+    Sse
+} from '@nestjs/common'
 import { Observable } from 'rxjs'
 import { HttpTestClient } from '../http.test-client'
 import { createHttpTestContext } from '../index'
@@ -26,9 +37,14 @@ class HttpTestClientController {
         return { ok: true }
     }
 
-    @Post('echo')
-    echo(@Body() body: any) {
-        return body
+    @Post('body-merging')
+    verifyBodyMerging(@Body() body: Record<string, unknown>) {
+        if (body.first !== true || body.second !== true) {
+            throw new BadRequestException('both body fragments are required')
+        }
+
+        // 요청에 들어온 임의 값을 반사하지 않고, 검증 결과만 JSON으로 응답한다.
+        return { first: true, second: true }
     }
 
     // multipart 등 임의 요청 검증용이다. 본문 파싱 없이 원본 스트림을 모아 반환한다.

--- a/libs/testing/src/__tests__/http.test-client.spec.ts
+++ b/libs/testing/src/__tests__/http.test-client.spec.ts
@@ -91,14 +91,16 @@ describe('HttpTestClient', () => {
 
     describe('체인 메서드', () => {
         it('body()를 두 번 호출하면 두 번째 호출까지 결과에 포함된다', async () => {
-            const { body } = await fix.httpClient
-                .post('/echo')
-                .body({ first: true })
+            const response = await fix.httpClient
+                .post('/body-merging')
+                .body({ first: true, untrusted: '<script>alert(1)</script>' })
                 .body({ second: true })
                 .created()
 
             // superagent.send는 같은 contentType이면 두 번째 호출의 객체를 병합한다.
-            expect(body).toEqual({ first: true, second: true })
+            expect(response.body).toEqual({ first: true, second: true })
+            expect(response.type).toBe('application/json')
+            expect(response.text).not.toContain('<script>')
         })
     })
 })

--- a/tests/api-perf/harness-crud.js
+++ b/tests/api-perf/harness-crud.js
@@ -26,6 +26,7 @@ import {
     buildSummary,
     measurementStart,
     readOptions,
+    secureRandomHex,
     summaryReturn
 } from './perf-common.js'
 
@@ -40,7 +41,7 @@ const statusCounter = new Counter('measured_status')
 export const options = buildScenarioOptions(opts)
 
 function uniqueEmail(vu, iter) {
-    return `perf.${Date.now()}.${vu}.${iter}.${Math.random().toString(36).slice(2, 8)}@example.com`
+    return `perf.${Date.now()}.${vu}.${iter}.${secureRandomHex()}@example.com`
 }
 
 const SCENARIOS = {
@@ -63,7 +64,7 @@ const SCENARIOS = {
         method: 'POST',
         path: '/theaters',
         body: {
-            name: `perf-theater-${Date.now()}-${vu}-${iter}-${Math.random().toString(36).slice(2, 8)}`,
+            name: `perf-theater-${Date.now()}-${vu}-${iter}-${secureRandomHex()}`,
             location: { latitude: 37.5, longitude: 127.0 },
             seatmap: {
                 blocks: [
@@ -92,9 +93,7 @@ const SCENARIOS = {
     'movie-write': (vu, iter) => ({
         method: 'POST',
         path: '/movies',
-        body: {
-            title: `perf-movie-${Date.now()}-${vu}-${iter}-${Math.random().toString(36).slice(2, 8)}`
-        }
+        body: { title: `perf-movie-${Date.now()}-${vu}-${iter}-${secureRandomHex()}` }
     }),
     'movie-read-title-filter': () => ({
         method: 'GET',

--- a/tests/api-perf/harness-refresh.js
+++ b/tests/api-perf/harness-refresh.js
@@ -19,6 +19,7 @@ import {
     buildSummary,
     measurementStart,
     readOptions,
+    secureRandomHex,
     summaryReturn
 } from './perf-common.js'
 
@@ -32,7 +33,7 @@ export const options = buildScenarioOptions(opts)
 const JSON_HEADERS = { 'content-type': 'application/json', accept: 'application/json' }
 
 function uniqueEmail(vu, seed) {
-    return `perf-refresh.${seed}.${vu}.${Math.random().toString(36).slice(2, 8)}@example.com`
+    return `perf-refresh.${seed}.${vu}.${secureRandomHex()}@example.com`
 }
 
 export function setup() {

--- a/tests/api-perf/perf-common.js
+++ b/tests/api-perf/perf-common.js
@@ -1,3 +1,5 @@
+import crypto from 'k6/crypto'
+
 /**
  * k6 메트릭 모델에서 주의할 점:
  *  - Trend는 percentile만 보고 count는 없으므로 표본 수는 Counter(`measured_status`)로 같이 잰다.
@@ -9,6 +11,17 @@
 
 // 클라이언트 에러(연결 실패)는 k6가 0으로 보고한다.
 const TRACKED_STATUSES = [0, 200, 201, 204, 400, 401, 403, 404, 409, 422, 500, 502, 503]
+
+/** API로 전송할 고유 식별자를 k6의 CSPRNG로 만든다. */
+export function secureRandomHex(byteLength = 8) {
+    if (!Number.isInteger(byteLength) || byteLength <= 0) {
+        throw new Error('byteLength must be a positive integer')
+    }
+
+    return Array.from(new Uint8Array(crypto.randomBytes(byteLength)), (byte) =>
+        byte.toString(16).padStart(2, '0')
+    ).join('')
+}
 
 function readPositiveInt(name, defaultValue) {
     const raw = __ENV[name]

--- a/tests/api-race/jwt-refresh-race.js
+++ b/tests/api-race/jwt-refresh-race.js
@@ -4,7 +4,7 @@
  * 승자의 새 refresh token은 다시 회전돼 토큰 패밀리가 폐기되지 않았음을 증명해야 한다.
  */
 
-const { readPositiveInt, request, SERVER_URL } = require('./race-common')
+const { readPositiveInt, request, secureRandomHex, SERVER_URL } = require('./race-common')
 
 const USER_GROUPS = readPositiveInt('RACE_USER_GROUPS', 5)
 const CLIENTS_PER_USER = readPositiveInt('RACE_CLIENT_COUNT', 20)
@@ -12,7 +12,7 @@ const INNER_ITERATIONS = readPositiveInt('INNER_ITERATIONS', 30)
 const CONCURRENT_ERROR_CODE = 'ERR_JWT_AUTH_REFRESH_TOKEN_CONCURRENT'
 
 async function createAndLogin(suffix) {
-    const email = `race.${Date.now()}.${suffix}.${Math.random().toString(36).slice(2)}@example.com`
+    const email = `race.${Date.now()}.${suffix}.${secureRandomHex()}@example.com`
     const password = 'racepassword'
 
     const created = await request('POST', '/users', {

--- a/tests/api-race/purchase-double-spend.js
+++ b/tests/api-race/purchase-double-spend.js
@@ -3,7 +3,13 @@
  * 성공 응답은 구매 목록에서 다시 읽어 phantom 성공도 함께 막는다.
  */
 
-const { readPositiveInt, request, SERVER_URL, waitForSagaSuccess } = require('./race-common')
+const {
+    readPositiveInt,
+    request,
+    secureRandomHex,
+    SERVER_URL,
+    waitForSagaSuccess
+} = require('./race-common')
 
 const USER_GROUPS = readPositiveInt('PURCHASE_USER_GROUPS', 5)
 const PURCHASES_PER_GROUP = readPositiveInt('PURCHASE_CLIENT_COUNT', 50)
@@ -81,7 +87,7 @@ async function createShowtimeTickets(movieId, theaterId, startTimeOffsetMs) {
 }
 
 async function createAndLoginUser(index) {
-    const email = `purchase.${Date.now()}.${index}.${Math.random().toString(36).slice(2)}@example.com`
+    const email = `purchase.${Date.now()}.${index}.${secureRandomHex()}@example.com`
     const password = 'purchasepass'
     const create = await request('POST', '/users', {
         body: { name: `pur-${index}`, birthDate: '1990-01-01T00:00:00.000Z', email, password }

--- a/tests/api-race/purchase-overlap-race.js
+++ b/tests/api-race/purchase-overlap-race.js
@@ -3,7 +3,13 @@
  * 그룹마다 구매 기록 한 건과 Sold 티켓 두 장만 남아야 한다.
  */
 
-const { readPositiveInt, request, SERVER_URL, waitForSagaSuccess } = require('./race-common')
+const {
+    readPositiveInt,
+    request,
+    secureRandomHex,
+    SERVER_URL,
+    waitForSagaSuccess
+} = require('./race-common')
 
 const USER_GROUPS = readPositiveInt('PURCHASE_USER_GROUPS', 5)
 const INNER_ITERATIONS = readPositiveInt('INNER_ITERATIONS', 150)
@@ -81,7 +87,7 @@ async function createShowtimeTickets(movieId, theaterId, startTimeOffsetMs) {
 }
 
 async function createAndLoginUser(index) {
-    const email = `overlap.${Date.now()}.${index}.${Math.random().toString(36).slice(2)}@example.com`
+    const email = `overlap.${Date.now()}.${index}.${secureRandomHex()}@example.com`
     const password = 'overlappass'
     const create = await request('POST', '/users', {
         body: { name: `ovl-${index}`, birthDate: '1990-01-01T00:00:00.000Z', email, password }

--- a/tests/api-race/race-common.js
+++ b/tests/api-race/race-common.js
@@ -1,4 +1,5 @@
 const http = require('http')
+const { randomBytes, randomInt } = require('node:crypto')
 
 // race 시나리오는 runner.sh가 띄운 4-replica 배포 스택을 전제한다.
 // 기본값으로 단일 dev 서버에 조용히 붙으면 경쟁이 재현되지 않아 결과가 왜곡되므로 필수로 받는다.
@@ -20,6 +21,17 @@ function readPositiveInt(name, defaultValue) {
 
 const HTTP_REQUEST_TIMEOUT_MS = readPositiveInt('HTTP_REQUEST_TIMEOUT_MS', 30_000)
 const SSE_HANDSHAKE_TIMEOUT_MS = readPositiveInt('SSE_HANDSHAKE_TIMEOUT_MS', 30_000)
+
+function secureRandomHex(byteLength = 16) {
+    return randomBytes(byteLength).toString('hex')
+}
+
+function secureRandomIndex(length) {
+    if (!Number.isSafeInteger(length) || length <= 0) {
+        throw new Error('length must be a positive safe integer')
+    }
+    return randomInt(length)
+}
 
 /**
  * HTTP 요청 하나를 보내고 응답을 정규화해 돌려준다.
@@ -292,6 +304,8 @@ module.exports = {
     SERVER_URL,
     readPositiveInt,
     request,
+    secureRandomHex,
+    secureRandomIndex,
     openEventStream,
     waitUntil,
     waitForSagaSuccess

--- a/tests/api-race/replica-chaos.js
+++ b/tests/api-race/replica-chaos.js
@@ -4,7 +4,7 @@
  */
 
 const { execSync } = require('child_process')
-const { readPositiveInt, request } = require('./race-common')
+const { readPositiveInt, request, secureRandomHex, secureRandomIndex } = require('./race-common')
 
 const KILL_AT_MS = readPositiveInt('CHAOS_KILL_AT_MS', 30_000)
 const RESTART_AFTER_MS = readPositiveInt('CHAOS_RESTART_AFTER_MS', 30_000)
@@ -39,7 +39,7 @@ function bucketFor(state) {
 
 async function trafficWorker(workerId, state) {
     while (!state.stop) {
-        const email = `chaos.${Date.now()}.${workerId}.${Math.random().toString(36).slice(2)}@example.com`
+        const email = `chaos.${Date.now()}.${workerId}.${secureRandomHex()}@example.com`
         try {
             const r = await request('POST', '/users', {
                 body: {
@@ -75,7 +75,7 @@ async function main() {
     if (replicas.length < 4) {
         throw new Error(`expected 4 app replicas, got ${replicas.length}: ${replicas.join(',')}`)
     }
-    const target = replicas[Math.floor(Math.random() * replicas.length)]
+    const target = replicas[secureRandomIndex(replicas.length)]
     console.log(`[chaos] target=${target.slice(0, 12)} alive=${replicas.length}`)
 
     const state = { stop: false, phase: 'warmup', byPhase: {} }

--- a/tests/api-race/ticket-holding-race.js
+++ b/tests/api-race/ticket-holding-race.js
@@ -1,6 +1,12 @@
 // 같은 티켓 쌍을 여러 복제본에서 동시에 선점해 그룹마다 한 건만 204가 되는지 검증한다.
 
-const { readPositiveInt, request, SERVER_URL, waitForSagaSuccess } = require('./race-common')
+const {
+    readPositiveInt,
+    request,
+    secureRandomHex,
+    SERVER_URL,
+    waitForSagaSuccess
+} = require('./race-common')
 
 const TICKET_GROUPS = readPositiveInt('HOLD_TICKET_GROUPS', 5)
 const USERS_PER_GROUP = readPositiveInt('HOLD_CLIENT_COUNT', 50)
@@ -79,7 +85,7 @@ async function createShowtimeTickets(movieId, theaterId, startTimeOffsetMs) {
 }
 
 async function createAndLoginUser(index) {
-    const email = `hold.${Date.now()}.${index}.${Math.random().toString(36).slice(2)}@example.com`
+    const email = `hold.${Date.now()}.${index}.${secureRandomHex()}@example.com`
     const password = 'holdpassword'
     const create = await request('POST', '/users', {
         body: { name: `hold-${index}`, birthDate: '1990-01-01T00:00:00.000Z', email, password }

--- a/tests/api-race/user-signup-race.js
+++ b/tests/api-race/user-signup-race.js
@@ -1,6 +1,6 @@
 // 같은 이메일 가입을 여러 복제본에 동시에 보내 정확히 한 건만 201이 되는지 검증한다.
 
-const { readPositiveInt, request, SERVER_URL } = require('./race-common')
+const { readPositiveInt, request, secureRandomHex, SERVER_URL } = require('./race-common')
 
 const EMAIL_GROUPS = readPositiveInt('RACE_EMAIL_GROUPS', 10)
 const CLIENTS_PER_GROUP = readPositiveInt('RACE_CLIENT_COUNT', 50)
@@ -9,8 +9,7 @@ const INNER_ITERATIONS = readPositiveInt('INNER_ITERATIONS', 30)
 async function runInner(iteration) {
     const emails = Array.from(
         { length: EMAIL_GROUPS },
-        (_, g) =>
-            `race.${Date.now()}.${iteration}.${g}.${Math.random().toString(36).slice(2)}@example.com`
+        (_, g) => `race.${Date.now()}.${iteration}.${g}.${secureRandomHex()}@example.com`
     )
 
     const requests = emails.flatMap((email) =>

--- a/tests/console-e2e/tests/console-auth-flow.spec.ts
+++ b/tests/console-e2e/tests/console-auth-flow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, request, test, type BrowserContext, type Page } from '@playwright/test'
+import { randomBytes, randomUUID } from 'node:crypto'
 
 import { API_BASE_URL } from '../playwright.config'
 
@@ -198,10 +199,8 @@ test('관리자 로그아웃은 쿠키와 서버 refresh 토큰을 함께 폐기
 
 test('BFF가 전달한 클라이언트 IP별로 로그인 실패 한도를 격리한다', async ({ page }) => {
     await page.goto('/login')
-    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
-    const addressSeed = Math.floor(Math.random() * 0x1_0000_0000)
-        .toString(16)
-        .padStart(8, '0')
+    const stamp = `${Date.now()}-${randomUUID()}`
+    const addressSeed = randomBytes(4).toString('hex')
     const firstIp = `2001:db8:${addressSeed.slice(0, 4)}:${addressSeed.slice(4)}::10`
     const secondIp = `2001:db8:${addressSeed.slice(0, 4)}:${addressSeed.slice(4)}::11`
 

--- a/tests/console-e2e/tests/user-auth-flow.spec.ts
+++ b/tests/console-e2e/tests/user-auth-flow.spec.ts
@@ -43,7 +43,7 @@ test.beforeAll(async () => {
 })
 
 async function signupAndLogin(page: Page): Promise<string> {
-    const email = `e2e-user-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`
+    const email = `e2e-user-${Date.now()}-${randomUUID()}@example.com`
 
     await page.goto(`${USER_APP_BASE_URL}/signup`)
     await page.getByRole('textbox', { name: '이름' }).fill('E2E User')

--- a/tools/jest-helpers/index.js
+++ b/tools/jest-helpers/index.js
@@ -5,7 +5,7 @@ const {
     ListBucketsCommand,
     ListObjectsV2Command
 } = require('@aws-sdk/client-s3')
-const { randomBytes } = require('node:crypto')
+const { randomBytes, randomInt } = require('node:crypto')
 
 const WORKER_DB_PATTERN = /^mongo-w\d+$/
 const WORKER_BUCKET_PATTERN = /^s3bucket-w\d+$/
@@ -42,9 +42,7 @@ function createJestResourceScope(runId) {
 
 function generateTestId() {
     const chars = 'useandom26T198340PX75pxJACKVERYMINDBUSHWOLFGQZbfghjklqvwyzrict'
-    return Array.from({ length: 10 }, () => chars[Math.floor(Math.random() * chars.length)]).join(
-        ''
-    )
+    return Array.from({ length: 10 }, () => chars[randomInt(chars.length)]).join('')
 }
 
 async function cleanCollections(mongoClient, dbName) {


### PR DESCRIPTION
## Summary
- replace all `Math.random()` usage with runtime-native cryptographic randomness, including the Redis lock owner token
- use k6 `k6/crypto` for performance-test identifiers and Node `crypto` for race/E2E/Jest identifiers
- replace the reflected test echo endpoint with a fixed JSON projection after strict input checks
- add an XSS regression assertion proving attacker-controlled markup is not reflected

## Verification
- `npm test -w libs/testing -- --runInBand` (61 tests)
- `npm test -w libs/common -- --runInBand` (654 tests, 100% coverage)
- `npm run atoz -w tests/api-race`
- `npm run lint -w tests/console-e2e`
- `npm test -w tests/console-e2e` (12 tests)
- `npm run test:config`
- `npm run lint`
- k6 v2.2 `secureRandomHex()` runtime smoke test
- repository contains no `Math.random()` calls

Closes code-scanning alerts #43, #44, and #45 after the main-branch CodeQL scan.