### PR TITLE
chore: use Docker Hub for VersityGW

### DIFF
--- a/.env.infra
+++ b/.env.infra
@@ -1,4 +1,4 @@
-S3_IMAGE=ghcr.io/versity/versitygw:v1.7.0@sha256:c4cbd9d9cb8dedbb055ac788dbd02635651b9b1cebac95b095b3217231aa87ad
+S3_IMAGE=versity/versitygw:v1.7.0@sha256:c4cbd9d9cb8dedbb055ac788dbd02635651b9b1cebac95b095b3217231aa87ad
 # @testcontainers/mongodb는 MONGO_IMAGE의 tag를 semver로 읽어 mongosh 사용 여부를 정하므로 digest를 분리한다.
 # Compose는 두 값을 다시 `tag@digest`로 결합한다.
 MONGO_IMAGE=mongo:8.3.8


### PR DESCRIPTION
## Summary
- switch the VersityGW image reference from GHCR to the official Docker Hub repository
- keep v1.7.0 and the existing OCI digest unchanged

## Verification
- npm run test:config
- npm run postlint
- docker compose config
- Docker Hub manifest digest inspection and exact digest pull