### PR TITLE
chore: declare webpack node externals

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -73,6 +73,7 @@
         "ts-loader": "9.6.2",
         "tsx": "4.23.12",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.67.0"
+        "typescript-eslint": "8.67.0",
+        "webpack-node-externals": "3.0.0"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,8 @@
                 "ts-loader": "9.6.2",
                 "tsx": "4.23.12",
                 "typescript": "6.0.3",
-                "typescript-eslint": "8.67.0"
+                "typescript-eslint": "8.67.0",
+                "webpack-node-externals": "3.0.0"
             }
         },
         "apps/api/node_modules/@angular-devkit/core": {


### PR DESCRIPTION
## Summary
- declare webpack-node-externals as a direct API dev dependency
- stop relying on the package being hoisted transitively from the Nest CLI
- keep the existing resolved version at 3.0.0

## Verification
- npm run build --workspace apps/api
- npm run lint --workspace apps/api
- npm run test:config
- npm run postlint
- npm ls webpack-node-externals --all