### PR TITLE
refactor: align backend ESM and test conventions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,30 +9,17 @@ RUN set -eu; \
     case "$TARGETARCH" in \
     amd64 | arm64) ;; \
     *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
-    esac; \
-    node --version; \
-    npm --version
+    esac
 
 RUN set -eu; apt-get update; DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
     ca-certificates curl git iproute2 jq shellcheck shfmt tmux tree unzip xz-utils; \
-    rm -rf /var/lib/apt/lists/*; \
-    curl --version; \
-    git --version; \
-    ip -Version; \
-    jq --version; \
-    shellcheck --version; \
-    shfmt -version; \
-    tmux -V; \
-    tree --version; \
-    unzip -v | sed -n '1p'; \
-    xz --version
+    rm -rf /var/lib/apt/lists/*
 
 # OS 의존성은 이미지에 두고, lockfile과 일치하는 Chromium은 postCreateCommand에서 설치한다.
 RUN set -eu; \
     npm install --global --no-audit --no-fund playwright; \
     playwright install-deps chromium; \
-    playwright --version; \
     npm cache clean --force; \
     rm -rf /var/lib/apt/lists/*
 
@@ -43,8 +30,7 @@ RUN set -eu; apt-get update; DEBIAN_FRONTEND=noninteractive \
     https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar -o /tmp/plantuml.jar; \
     install -m 0644 /tmp/plantuml.jar /opt/plantuml.jar; \
     rm -f /tmp/plantuml.jar; \
-    rm -rf /var/lib/apt/lists/*; \
-    java -jar /opt/plantuml.jar -version
+    rm -rf /var/lib/apt/lists/*
 
 RUN set -eu; \
     case "$TARGETARCH" in \
@@ -56,8 +42,7 @@ RUN set -eu; \
     "https://github.com/lycheeverse/lychee/releases/latest/download/${archive}.tar.gz" -o /tmp/lychee.tar.gz; \
     tar -xzf /tmp/lychee.tar.gz -C /tmp; \
     install -m 0755 "/tmp/${archive}/lychee" /usr/local/bin/lychee; \
-    rm -rf /tmp/lychee.tar.gz "/tmp/${archive}"; \
-    lychee --version
+    rm -rf /tmp/lychee.tar.gz "/tmp/${archive}"
 
 RUN set -eu; \
     suffix="linux-${TARGETARCH}.tar.gz"; \
@@ -69,17 +54,14 @@ RUN set -eu; \
     mkdir /tmp/k6; \
     tar -xzf /tmp/k6.tar.gz -C /tmp/k6 --strip-components=1; \
     install -m 0755 /tmp/k6/k6 /usr/local/bin/k6; \
-    rm -rf /tmp/k6.tar.gz /tmp/k6; \
-    k6 version
+    rm -rf /tmp/k6.tar.gz /tmp/k6
 
 RUN set -eu; \
     curl -fsSL --retry 3 --retry-all-errors \
     "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${TARGETARCH}" -o /tmp/cloudflared; \
     install -m 0755 /tmp/cloudflared /usr/local/bin/cloudflared; \
-    rm -f /tmp/cloudflared; \
-    cloudflared --version
+    rm -f /tmp/cloudflared
 
 RUN set -eu; \
     npm install --global --no-audit --no-fund pnpm; \
-    pnpm --version; \
     npm cache clean --force

--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json.schemastore.org/nest-cli",
     "collection": "@nestjs/schematics",
-    "compilerOptions": { "deleteOutDir": true, "builder": "tsc" },
+    "compilerOptions": {
+        "deleteOutDir": true,
+        "builder": "tsc",
+        "tsConfigPath": "tsconfig.build.json"
+    },
     "entryFile": "development",
     "sourceRoot": "src"
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "start": "node --enable-source-maps _output/dist/index.js",
         "format": "prettier --write src/ scripts/ '*.{cjs,mjs}'",
-        "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ scripts/ ./*.cjs ./*.mjs && prettier --check src/ scripts/ '*.{cjs,mjs}'",
+        "lint": "tsc --noEmit -p tsconfig.build.json && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ scripts/ ./*.cjs ./*.mjs && prettier --check src/ scripts/ '*.{cjs,mjs}'",
         "build": "nest build -b rspack --rspackPath rspack.config.cjs",
         "predev": "free-port ${API_PORT:?}",
         "dev": "nest start --watch",

--- a/apps/api/src/__tests__/application/purchase-events.spec.ts
+++ b/apps/api/src/__tests__/application/purchase-events.spec.ts
@@ -54,7 +54,7 @@ describe('PurchaseEvents', () => {
 
     it('알림 소비자가 중단된 동안 발행한 이벤트를 재시작 뒤 처리한다', async () => {
         const { PurchaseNotificationService } =
-            await import('../../services/application/purchase/internal/purchase-notification.service.js')
+            await import('../../services/application/purchase/internal/index.js')
         const notification = fix.module.get(PurchaseNotificationService)
 
         await notification.onModuleDestroy()
@@ -264,7 +264,7 @@ function fakeMessages(
 async function createNotificationService(messages: ConsumerMessages) {
     const { Logger } = await import('@nestjs/common')
     const { PurchaseNotificationService } =
-        await import('../../services/application/purchase/internal/purchase-notification.service.js')
+        await import('../../services/application/purchase/internal/index.js')
     const fakeEvents = {
         consumeNotifications: vi.fn(async () => messages)
     } as unknown as PurchaseEvents

--- a/apps/api/src/__tests__/application/purchase.spec.ts
+++ b/apps/api/src/__tests__/application/purchase.spec.ts
@@ -1,7 +1,16 @@
+import type { MockInstance } from 'vitest'
 import { CacheService, DateUtil, ensure, objectId, pickIds, Require } from '@mannercode/common'
 import { HttpTestClient, oid } from '@mannercode/testing'
 import { createHash, randomUUID } from 'node:crypto'
-import { PurchaseItemType, TicketStatus, type TicketDto, type UserDto } from '#core'
+import type { PurchaseService } from '#application'
+import {
+    PurchaseItemType,
+    TicketStatus,
+    type PurchaseRecordDto,
+    type PurchaseRecordsService,
+    type TicketDto,
+    type UserDto
+} from '#core'
 import { PaymentStatus } from '#infrastructure'
 import {
     createAndLoginUser,
@@ -323,7 +332,7 @@ describe('PurchaseService', () => {
                     })
             })
 
-            it('구매하면 결제 기록이 생성된다', async () => {
+            it('결제 기록을 생성한다', async () => {
                 const createDto = buildCreatePurchaseDto(heldTickets)
                 const { body: purchaseRecord } = await fix.httpClient
                     .post('/purchases')
@@ -337,7 +346,7 @@ describe('PurchaseService', () => {
                 expect(ensure(payments[0]).amount).toEqual(purchaseRecord.totalPrice)
             })
 
-            it('구매하면 티켓 상태가 판매 완료로 바뀐다', async () => {
+            it('티켓 상태를 판매 완료로 바꾼다', async () => {
                 const createDto = buildCreatePurchaseDto(heldTickets)
                 await fix.httpClient
                     .post('/purchases')
@@ -512,99 +521,95 @@ describe('PurchaseService', () => {
             })
 
             describe('티켓이 Sold로 전이된 뒤 구매 완료 커밋이 실패할 때', () => {
+                let emit: MockInstance
+
                 // 보상 흐름이 실제로 Sold→Available 전이를 수행하는 경로를 검증한다.
                 // 위의 시나리오는 `completePurchase` 시작점에서 던지므로 티켓이 Available로 남아 보상은 no-op이지만, 여기는 전이 이후에 던져 보상이 진짜 되돌리기를 하도록 만든다.
                 beforeEach(async () => {
+                    const { PurchaseEvents } = await import('#application')
                     const { PurchaseRecordsService } = await import('#core')
+                    const events = fix.module.get(PurchaseEvents)
                     const purchaseRecordsService = fix.module.get(PurchaseRecordsService)
+                    emit = vi.spyOn(events, 'emitTicketPurchased')
                     vi.spyOn(purchaseRecordsService, 'markCompleted').mockRejectedValueOnce(
                         new Error('commit failed')
                     )
-                })
 
-                it('Sold가 된 티켓을 다시 Available로 되돌린다', async () => {
                     const createDto = buildCreatePurchaseDto(heldTickets)
-
                     await fix.httpClient
                         .post('/purchases')
                         .headers({ 'Idempotency-Key': randomUUID() })
                         .headers({ Authorization: `Bearer ${accessToken}` })
                         .body(createDto)
                         .internalServerError()
+                })
 
+                it('Sold가 된 티켓을 다시 Available로 되돌린다', async () => {
                     const { TicketsService } = await import('#core')
                     const ticketsService = fix.module.get(TicketsService)
                     const tickets = await ticketsService.getMany(pickIds(heldTickets))
                     expect(tickets.every((t) => t.status === TicketStatus.Available)).toBe(true)
                 })
+
+                it('구매 완료 이벤트를 발행하지 않는다', () => {
+                    expect(emit).not.toHaveBeenCalled()
+                })
             })
 
             describe('구매 완료 커밋 뒤 이벤트 발행이 실패할 때', () => {
-                it('구매는 유지하고 durable event를 후속 재발행한다', async () => {
+                let emit: MockInstance
+                let purchaseRecord: PurchaseRecordDto
+                let purchaseRecordsService: PurchaseRecordsService
+                let purchaseService: PurchaseService
+
+                beforeEach(async () => {
                     const { PurchaseEvents, PurchaseService } = await import('#application')
                     const { PurchaseRecordsService } = await import('#core')
                     const events = fix.module.get(PurchaseEvents)
-                    const purchaseService = fix.module.get(PurchaseService)
-                    const purchaseRecordsService = fix.module.get(PurchaseRecordsService)
-                    const emit = vi
+                    purchaseService = fix.module.get(PurchaseService)
+                    purchaseRecordsService = fix.module.get(PurchaseRecordsService)
+                    emit = vi
                         .spyOn(events, 'emitTicketPurchased')
                         .mockRejectedValueOnce(new Error('publish failed'))
 
                     const createDto = buildCreatePurchaseDto(heldTickets)
-                    const { body: purchaseRecord } = await fix.httpClient
+                    ;({ body: purchaseRecord } = await fix.httpClient
                         .post('/purchases')
                         .headers({ 'Idempotency-Key': randomUUID() })
                         .headers({ Authorization: `Bearer ${accessToken}` })
                         .body(createDto)
-                        .created()
+                        .created())
+                })
 
+                it('티켓·결제·구매 기록을 완료 상태로 유지한다', async () => {
                     expect(
                         (await getTickets(fix, pickIds(heldTickets))).every(
                             (ticket) => ticket.status === TicketStatus.Sold
                         )
                     ).toBe(true)
-                    expect(
-                        ensure((await getPayments(fix, [purchaseRecord.paymentId]))[0]).status
-                    ).toBe(PaymentStatus.Completed)
+
+                    const paymentId = ensure(purchaseRecord.paymentId)
+                    expect(ensure((await getPayments(fix, [paymentId]))[0]).status).toBe(
+                        PaymentStatus.Completed
+                    )
                     expect(await purchaseRecordsService.findByUserId(user.id)).toEqual([
                         expect.objectContaining({ id: purchaseRecord.id })
                     ])
+                })
+
+                it('durable event를 미발행 상태로 남긴다', async () => {
                     expect(
                         await purchaseRecordsService.findUnpublishedBefore(DateUtil.now())
                     ).toEqual([expect.objectContaining({ id: purchaseRecord.id })])
+                })
 
+                it('후속 발행에서 이벤트를 재발행하고 미발행 상태를 해제한다', async () => {
                     await purchaseService.publishPendingPurchaseEvents()
 
                     expect(emit).toHaveBeenCalledTimes(2)
                     expect(
                         await purchaseRecordsService.findUnpublishedBefore(DateUtil.now())
                     ).toEqual([])
-                })
-
-                it('완료 커밋이 실패하면 이벤트를 발행하지 않고 구매를 보상한다', async () => {
-                    const { PurchaseEvents } = await import('#application')
-                    const { PurchaseRecordsService } = await import('#core')
-                    const events = fix.module.get(PurchaseEvents)
-                    const purchaseRecordsService = fix.module.get(PurchaseRecordsService)
-                    vi.spyOn(purchaseRecordsService, 'markCompleted').mockRejectedValueOnce(
-                        new Error('commit failed')
-                    )
-                    const emit = vi.spyOn(events, 'emitTicketPurchased')
-
-                    const createDto = buildCreatePurchaseDto(heldTickets)
-                    await fix.httpClient
-                        .post('/purchases')
-                        .headers({ 'Idempotency-Key': randomUUID() })
-                        .headers({ Authorization: `Bearer ${accessToken}` })
-                        .body(createDto)
-                        .internalServerError()
-
-                    expect(emit).not.toHaveBeenCalled()
-                    expect(
-                        (await getTickets(fix, pickIds(heldTickets))).every(
-                            (ticket) => ticket.status === TicketStatus.Available
-                        )
-                    ).toBe(true)
                 })
             })
 

--- a/apps/api/src/__tests__/application/recommendation.spec.ts
+++ b/apps/api/src/__tests__/application/recommendation.spec.ts
@@ -74,7 +74,7 @@ describe('RecommendationService', () => {
             })
         })
 
-        describe('게스트일 때', () => {
+        describe('게스트 추천', () => {
             it('개봉일 내림차순 기본 추천을 반환한다', async () => {
                 const { body } = await fix.httpClient.get('/views/user-app/home').ok()
 

--- a/apps/api/src/__tests__/core/admin-auth.spec.ts
+++ b/apps/api/src/__tests__/core/admin-auth.spec.ts
@@ -36,8 +36,7 @@ describe('AdminAuthentication', () => {
         })
 
         it('authVersion 필드가 없는 기존 관리자도 version 0 세션으로 로그인한다', async () => {
-            const { AdminsRepository } =
-                await import('../../services/core/admins/admins.repository.js')
+            const { AdminsRepository } = await import('../../services/core/admins/index.js')
             const repository = fix.module.get(AdminsRepository)
             await repository.collection.updateOne(
                 { email: credentials.email },

--- a/apps/api/src/__tests__/core/admin-management.spec.ts
+++ b/apps/api/src/__tests__/core/admin-management.spec.ts
@@ -196,43 +196,37 @@ describe('AdminManagement', () => {
                     .ok({ ...admin, name: 'renamed' })
             })
 
-            it('자기 password를 바꾸면 새 password로 로그인할 수 있다', async () => {
-                await fix.httpClient
-                    .patch('/admins/me')
-                    .headers({ Authorization: `Bearer ${accessToken}` })
-                    .body({ password: 'newPassword' })
-                    .ok()
+            describe('password를 변경하면', () => {
+                const newPassword = 'newPassword'
 
-                await fix.httpClient
-                    .post('/admins/login')
-                    .body({ email: adminCredentials.email, password: 'newPassword' })
-                    .ok({ accessToken: expect.any(String), refreshToken: expect.any(String) })
-            })
+                beforeEach(async () => {
+                    await fix.httpClient
+                        .patch('/admins/me')
+                        .headers({ Authorization: `Bearer ${accessToken}` })
+                        .body({ password: newPassword })
+                        .ok()
+                })
 
-            it('password를 바꾸면 기존 리프레시 토큰은 더 이상 갱신되지 않는다', async () => {
-                await fix.httpClient
-                    .patch('/admins/me')
-                    .headers({ Authorization: `Bearer ${accessToken}` })
-                    .body({ password: 'newPassword' })
-                    .ok()
+                it('새 password로 로그인할 수 있다', async () => {
+                    await fix.httpClient
+                        .post('/admins/login')
+                        .body({ email: adminCredentials.email, password: newPassword })
+                        .ok({ accessToken: expect.any(String), refreshToken: expect.any(String) })
+                })
 
-                await fix.httpClient
-                    .post('/admins/refresh')
-                    .body({ refreshToken })
-                    .unauthorized(Errors.JwtAuth.RefreshTokenInvalid())
-            })
+                it('기존 리프레시 토큰은 더 이상 갱신되지 않는다', async () => {
+                    await fix.httpClient
+                        .post('/admins/refresh')
+                        .body({ refreshToken })
+                        .unauthorized(Errors.JwtAuth.RefreshTokenInvalid())
+                })
 
-            it('password를 바꾸면 기존 액세스 토큰을 즉시 거부한다', async () => {
-                await fix.httpClient
-                    .patch('/admins/me')
-                    .headers({ Authorization: `Bearer ${accessToken}` })
-                    .body({ password: 'newPassword' })
-                    .ok()
-
-                await fix.httpClient
-                    .get('/admins/me')
-                    .headers({ Authorization: `Bearer ${accessToken}` })
-                    .unauthorized(Errors.Auth.Unauthorized())
+                it('기존 액세스 토큰을 즉시 거부한다', async () => {
+                    await fix.httpClient
+                        .get('/admins/me')
+                        .headers({ Authorization: `Bearer ${accessToken}` })
+                        .unauthorized(Errors.Auth.Unauthorized())
+                })
             })
 
             it('email을 변경하면 변경된 email을 반환한다', async () => {

--- a/apps/api/src/__tests__/core/ticket-holding.spec.ts
+++ b/apps/api/src/__tests__/core/ticket-holding.spec.ts
@@ -100,20 +100,6 @@ describe('TicketHoldingService', () => {
             })
         })
 
-        it('보유 시간이 만료되면 다른 고객이 같은 티켓을 잡을 수 있다', async () => {
-            await overrideConfigGetter(fix.module, 'ticket', { holdDurationInMs: 1000 })
-
-            const holdDto = buildHoldTicketsDto({ userId: oid(0xc1) })
-            await ticketHoldingService.holdTickets(holdDto)
-
-            await sleep(1000 + 500)
-
-            const otherHold = buildHoldTicketsDto({ userId: oid(0xc2) })
-            const isHeld = await ticketHoldingService.holdTickets(otherHold)
-
-            expect(isHeld).toBe(true)
-        })
-
         it(
             '여러 고객이 동시에 보유를 시도하면 상영 한 건당 한 명만 성공한다',
             async () => {
@@ -152,21 +138,31 @@ describe('TicketHoldingService', () => {
 
             expect(heldTicketIds).toEqual(holdDto.ticketIds)
         })
+    })
 
-        it('보유 시간이 만료되면 빈 배열을 반환한다', async () => {
+    describe('보유 시간이 만료되면', () => {
+        let holdDto: ReturnType<typeof buildHoldTicketsDto>
+
+        beforeEach(async () => {
             await overrideConfigGetter(fix.module, 'ticket', { holdDurationInMs: 1000 })
-
-            const holdDto = buildHoldTicketsDto()
+            holdDto = buildHoldTicketsDto({ userId: oid(0xc1) })
             await ticketHoldingService.holdTickets(holdDto)
-
             await sleep(1000 + 500)
+        })
 
+        it('빈 보유 목록을 반환한다', async () => {
             const heldTicketIds = await ticketHoldingService.searchHeldTicketIds(
                 holdDto.showtimeId,
                 holdDto.userId
             )
 
             expect(heldTicketIds).toHaveLength(0)
+        })
+
+        it('다른 고객이 같은 티켓을 잡을 수 있다', async () => {
+            const isHeld = await ticketHoldingService.holdTickets({ ...holdDto, userId: oid(0xc2) })
+
+            expect(isHeld).toBe(true)
         })
     })
 

--- a/apps/api/src/__tests__/core/user-auth.spec.ts
+++ b/apps/api/src/__tests__/core/user-auth.spec.ts
@@ -76,8 +76,7 @@ describe('UserAuthentication', () => {
         })
 
         it('authVersion 필드가 없는 기존 사용자도 version 0 세션으로 로그인한다', async () => {
-            const { UsersRepository } =
-                await import('../../services/core/users/users.repository.js')
+            const { UsersRepository } = await import('../../services/core/users/index.js')
             const repository = fix.module.get(UsersRepository)
             await repository.collection.updateOne(
                 { email: credentials.email },

--- a/apps/api/src/__tests__/core/users.spec.ts
+++ b/apps/api/src/__tests__/core/users.spec.ts
@@ -7,6 +7,7 @@ import {
     createAndLoginUser,
     createUser,
     Errors,
+    loginUser,
     type AppTestContext
 } from '../helpers/index.js'
 
@@ -151,32 +152,35 @@ describe('UsersService', () => {
                 .notFound(Errors.Mongo.DocumentNotFound(nullObjectId))
         })
 
-        it('password를 바꾸면 새 password로 로그인할 수 있다', async () => {
-            await fix.httpClient
-                .patch(`/users/${user.id}`)
-                .headers(adminAuth)
-                .body({ password: 'newPassword' })
-                .ok()
+        describe('password를 변경하면', () => {
+            const newPassword = 'newPassword'
+            let refreshToken: string
 
-            await fix.httpClient
-                .post('/users/login')
-                .body({ email: user.email, password: 'newPassword' })
-                .ok({ accessToken: expect.any(String), refreshToken: expect.any(String) })
-        })
+            beforeEach(async () => {
+                ;({ refreshToken } = await loginUser(fix, {
+                    email: user.email,
+                    password: 'password'
+                }))
+                await fix.httpClient
+                    .patch(`/users/${user.id}`)
+                    .headers(adminAuth)
+                    .body({ password: newPassword })
+                    .ok()
+            })
 
-        it('password를 바꾸면 기존 리프레시 토큰은 더 이상 갱신되지 않는다', async () => {
-            const session = await createAndLoginUser(fix)
+            it('새 password로 로그인할 수 있다', async () => {
+                await fix.httpClient
+                    .post('/users/login')
+                    .body({ email: user.email, password: newPassword })
+                    .ok({ accessToken: expect.any(String), refreshToken: expect.any(String) })
+            })
 
-            await fix.httpClient
-                .patch(`/users/${session.user.id}`)
-                .headers(adminAuth)
-                .body({ password: 'newPassword' })
-                .ok()
-
-            await fix.httpClient
-                .post('/users/refresh')
-                .body({ refreshToken: session.refreshToken })
-                .unauthorized(Errors.JwtAuth.RefreshTokenInvalid())
+            it('기존 리프레시 토큰은 더 이상 갱신되지 않는다', async () => {
+                await fix.httpClient
+                    .post('/users/refresh')
+                    .body({ refreshToken })
+                    .unauthorized(Errors.JwtAuth.RefreshTokenInvalid())
+            })
         })
 
         it('다른 고객의 이메일로 변경하면 409를 반환한다', async () => {

--- a/apps/api/src/config/__tests__/app-config.service.spec.ts
+++ b/apps/api/src/config/__tests__/app-config.service.spec.ts
@@ -1,5 +1,5 @@
 import type { ConfigService } from '@nestjs/config'
-import { AppConfigService } from '../app-config.service.js'
+import { AppConfigService } from '../index.js'
 
 describe('AppConfigService schema', () => {
     const portSchema = AppConfigService.schema.pick({ API_PORT: true })

--- a/apps/api/src/config/__tests__/connections.spec.ts
+++ b/apps/api/src/config/__tests__/connections.spec.ts
@@ -1,5 +1,5 @@
 import type { Db, MongoClient } from 'mongodb'
-import { MongoConnection } from '../connections.js'
+import { MongoConnection } from '../index.js'
 
 describe('MongoConnection', () => {
     it('소유한 client는 모듈 종료 시 닫는다', async () => {

--- a/apps/api/src/config/__tests__/mongo-driver-options.spec.ts
+++ b/apps/api/src/config/__tests__/mongo-driver-options.spec.ts
@@ -1,4 +1,4 @@
-import { createMongoDriverOptions } from '../mongo-driver-options.js'
+import { createMongoDriverOptions } from '../index.js'
 
 describe('createMongoDriverOptions', () => {
     it('프로세스 수명의 애플리케이션 풀은 운영 idle capacity를 유지한다', () => {

--- a/apps/api/src/modules/health/__tests__/restate.health-indicator.spec.ts
+++ b/apps/api/src/modules/health/__tests__/restate.health-indicator.spec.ts
@@ -1,5 +1,5 @@
 import type { AppConfigService } from '#config'
-import { RestateHealthIndicator } from '../restate.health-indicator.js'
+import { RestateHealthIndicator } from '../index.js'
 
 describe('RestateHealthIndicator', () => {
     const config = {

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/restate-endpoint.service.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/restate-endpoint.service.spec.ts
@@ -3,8 +3,7 @@ import { type LoggerTransport, workflow } from '@restatedev/restate-sdk'
 import { once } from 'node:events'
 import { connect } from 'node:http2'
 import type { AppConfigService } from '#config'
-import type { ShowtimeCreationWorkflow } from '../workflow.js'
-import { ShowtimeCreationRestateEndpoint } from '../restate-endpoint.service.js'
+import { ShowtimeCreationRestateEndpoint, type ShowtimeCreationWorkflow } from '../index.js'
 
 describe('ShowtimeCreationRestateEndpoint', () => {
     it('Vitest에서는 임의 포트로 열고 HTTP/2 session까지 정상 종료한다', async () => {

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/restate-workflow-client.service.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/restate-workflow-client.service.spec.ts
@@ -5,8 +5,7 @@ import { instant } from '@mannercode/testing'
 import { workflow } from '@restatedev/restate-sdk'
 import type { AppConfigService } from '#config'
 import type { ShowtimeCreationTerminalEvent } from '../../internal/index.js'
-import type { ShowtimeCreationWorkflow } from '../workflow.js'
-import { ShowtimeCreationWorkflowClient } from '../restate-workflow-client.service.js'
+import { ShowtimeCreationWorkflowClient, type ShowtimeCreationWorkflow } from '../index.js'
 import { TemporalJsonSerde } from '../temporal-json.serde.js'
 
 const restateMocks = vi.hoisted(() => ({ connect: vi.fn() }))

--- a/apps/api/src/services/application/showtime-creation/worker/__tests__/workflow.spec.ts
+++ b/apps/api/src/services/application/showtime-creation/worker/__tests__/workflow.spec.ts
@@ -7,14 +7,14 @@ import type {
     ShowtimeCreationTerminalEvent,
     ValidateAndCreateResult
 } from '../../internal/index.js'
-import type { ShowtimeCreationWorkflowInput } from '../types.js'
 import { TemporalJsonSerde } from '../temporal-json.serde.js'
 import {
     createShowtimeCreationWorkflow,
     getShowtimeCreationWorkflowName,
     ShowtimeCreationWorkflow,
-    type ShowtimeCreationWorkflowDefinition
-} from '../workflow.js'
+    type ShowtimeCreationWorkflowDefinition,
+    type ShowtimeCreationWorkflowInput
+} from '../index.js'
 
 describe('Showtime creation Restate workflow', () => {
     const input = {

--- a/apps/api/src/services/core/users/__tests__/users-pagination.spec.ts
+++ b/apps/api/src/services/core/users/__tests__/users-pagination.spec.ts
@@ -1,4 +1,4 @@
-import { UsersRepository } from '../users.repository.js'
+import { UsersRepository } from '../index.js'
 
 describe('UsersRepository pagination', () => {
     it('null pagination 값을 undefined로 정규화하고 값이 있으면 유지한다', async () => {

--- a/apps/api/src/services/core/users/__tests__/users-write-concern-recovery.spec.ts
+++ b/apps/api/src/services/core/users/__tests__/users-write-concern-recovery.spec.ts
@@ -1,8 +1,7 @@
 import { plainDate } from '@mannercode/testing'
 import { ConflictException } from '@nestjs/common'
 import { ObjectId, type Collection, type Document } from 'mongodb'
-import { UsersRepository } from '../users.repository.js'
-import { UsersService } from '../users.service.js'
+import { UsersRepository, UsersService } from '../index.js'
 
 describe('user create write concern recovery', () => {
     const createDto = {

--- a/apps/api/src/services/gateway/pipes/__tests__/request-validation.pipe.fixture.ts
+++ b/apps/api/src/services/gateway/pipes/__tests__/request-validation.pipe.fixture.ts
@@ -2,7 +2,7 @@ import { createHttpTestContext, type HttpTestContext } from '@mannercode/testing
 import { Body, Controller, Post } from '@nestjs/common'
 import { APP_PIPE } from '@nestjs/core'
 import { z } from 'zod'
-import { RequestValidationPipe } from '../request-validation.pipe.js'
+import { RequestValidationPipe } from '../index.js'
 
 export type RequestValidationPipeFixture = HttpTestContext & { teardown: () => Promise<void> }
 

--- a/apps/api/src/services/gateway/pipes/__tests__/request-validation.pipe.spec.ts
+++ b/apps/api/src/services/gateway/pipes/__tests__/request-validation.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { nullDate } from '@mannercode/testing'
 import type { RequestValidationPipeFixture } from './request-validation.pipe.fixture.js'
-import { RequestValidationPipe } from '../request-validation.pipe.js'
+import { RequestValidationPipe } from '../index.js'
 
 describe('RequestValidationPipe', () => {
     let fix: RequestValidationPipeFixture

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,1 +1,6 @@
-{ "extends": "./tsconfig.json", "include": ["src/**/*"] }
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": { "types": ["node"] },
+    "include": ["src/**/*"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,6 +4,7 @@
         "incremental": true,
         "rootDir": ".",
         "outDir": "./_output/build",
+        "types": ["node", "vitest/globals"],
         "paths": {
             "#application": ["./src/services/application/index.ts"],
             "#config": ["./src/config/index.ts"],
@@ -13,6 +14,5 @@
             "#view": ["./src/services/view/index.ts"]
         }
     },
-    "include": ["src/**/*", "scripts/**/*"],
-    "exclude": ["src/**/__tests__/**"]
+    "include": ["src/**/*", "scripts/**/*"]
 }

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -343,7 +343,7 @@ export const MovieErrors = {
 지켜야 할 약속은 다음과 같다.
 
 - 에러 정의는 서비스 디렉터리 안의 `errors.ts` 파일로 분리한다. 서비스 클래스 파일 안에 함께 적지 않는다.
-- 같은 디렉터리의 `index.ts`에서 `export * from './errors'`로 다시 내보낸다.
+- 같은 디렉터리의 `index.ts`에서 `export * from './errors.js'`로 다시 내보낸다.
 - 단순 파싱/검증처럼 한 파일 안에서만 쓰는 gateway 계층의 에러는 예외적으로 가까운 곳에 둘 수 있다. 예: `RequestValidationPipeErrors`, URL 날짜 파싱 에러. 여러 핸들러나 서비스에서 재사용되면 `errors.ts`로 옮긴다.
 - 클라이언트가 분기해야 하는 HTTP 4xx 응답에 `code`를 함께 보낸다. 5xx는 서버 장애이므로 클라이언트에게 자세한 원인을 노출하지 않는다.
 - `message`는 디버깅과 로그를 위한 참고 값이다. 화면에 보여 줄 문구는 클라이언트가 `code`를 보고 정한다.
@@ -352,24 +352,46 @@ export const MovieErrors = {
 
 각 폴더에는 `index.ts`를 둔다. 폴더 밖에서 사용해도 되는 것만 `index.ts`에서 다시 내보낸다. 이렇게 하면 공개 API를 한눈에 볼 수 있다.
 
+#### ESM에서 경로를 읽는 법
+
+백엔드 TypeScript workspace는 `package.json`의 `"type": "module"`과 TypeScript의 `NodeNext` 모드로 Native ESM을 사용한다. 소스 파일 이름과 import 문자열이 가리키는 런타임 파일 이름을 구분해서 읽는다.
+
+| 작성 중인 파일   | 코드에 쓰는 경로     | Node가 실행할 때 찾는 파일  |
+| ---------------- | -------------------- | --------------------------- |
+| `errors.ts`      | `./errors.js`        | 빌드된 `errors.js`          |
+| `index.ts`       | `../index.js`        | 빌드된 `index.js`           |
+| workspace 패키지 | `@mannercode/common` | 패키지의 `main`/`exports`   |
+| API 내부 별칭    | `#core`              | `package.json#imports` 경로 |
+
+따라서 TypeScript 파일에서 `import './errors.js'`라고 써도 옆에 실제 `errors.js` 소스가 있어야 한다는 뜻이 아니다. TypeScript는 `NodeNext` 규칙으로 그 경로를 `errors.ts`에 연결해 타입을 검사하고, 문자열의 `.js`는 그대로 남아 빌드 산출물에서 유효해진다.
+
+- `./`, `../`로 시작하는 상대 경로에는 런타임 확장자 `.js`를 쓴다. 일반 백엔드 소스에서 `.ts`를 직접 가져오지 않는다.
+- Node ESM은 확장자를 보충하거나 디렉터리의 `index.js`를 자동 탐색하지 않는다. `../index.js`까지 전부 쓴다.
+- 패키지 이름과 `#core` 같은 `package.json#imports` 별칭에는 `.js`를 덧붙이지 않는다.
+- `"type": "module"`인 패키지의 `.js`는 ESM이다. CommonJS로 실행해야 하는 설정·도구 파일은 `.cjs`, 패키지 설정과 무관하게 ESM임을 드러낼 파일은 `.mjs`를 쓴다.
+- ESM에는 전역 `require`, `module.exports`, `__dirname`, `__filename`이 없다. CommonJS 연동이 꼭 필요한 ESM 파일만 `createRequire(import.meta.url)`을 사용한다.
+- 타입으로만 쓰는 항목은 `import type`으로 가져온다. 이 import는 JavaScript 산출물에서 사라진다.
+
 가져오기 규칙은 두 가지이다.
 
 **상위 폴더는 상대 경로로 가져온다.** 절대 경로 별칭으로 상위 폴더를 가져오면 순환 참조가 생기기 쉽다. 상위 폴더의 `index.ts`(폴더의 공개 내보내기를 모은 파일, 보통 배럴이라고 부른다)가 다시 하위 모듈을 가져오기 때문이다.
 
 ```ts
 /* core/users/internal/user-authentication.service.ts */
-import { UsersRepository } from '../users.repository' // O
-import { UsersRepository } from 'core' // X — core의 index.ts가 users를 재참조해 순환이 생긴다
+import { UsersRepository } from '../users.repository.js' // O
+import { UsersRepository } from '#core' // X — core의 index.ts가 users를 재참조해 순환이 생긴다
 ```
 
 **상위 경로에 속하지 않는 폴더는 절대 경로로 가져온다.** 이런 경우 상대 경로를 쓰면 `../../../`가 길어져 읽기 어려워진다.
 
 ```ts
 /* gateway/users.http-controller.ts */
-import { UsersService } from 'core' // O — gateway에서 core는 형제 묶음이므로 별칭 사용
+import { UsersService } from '#core' // O — gateway에서 core는 형제 묶음이므로 별칭 사용
 ```
 
-모든 가져오기가 `index.ts`를 지나가면 의존 그래프가 단순해진다. 순환 참조가 생겨도 빌드 오류로 빨리 드러난다.
+폴더 경계를 넘는 공개 API 가져오기가 `index.ts`를 지나가면 의존 그래프가 단순해진다. 순환 참조가 생겨도 빌드 오류로 빨리 드러난다.
+
+`__tests__`는 애플리케이션의 모듈 의존 그래프에 포함되지 않으므로 공개 항목을 테스트할 때 해당 모듈의 `../index.js`에서 가져온다. 그래야 실제 소비자가 사용하는 공개 export도 함께 검증된다. 테스트 fixture에도 같은 규칙을 적용하며, `index.ts`로 내보내지 않은 의도적인 내부 구현을 직접 검증할 때만 구현 파일을 가져온다. Native ESM은 디렉터리의 `index.js`를 자동 탐색하지 않으므로 `../`처럼 생략하지 않고 `../index.js`까지 명시한다. 이 규칙은 `oxlint.json`의 `no-restricted-imports`가 강제하며, 비공개 구현의 직접 import는 같은 설정의 명시적 허용 목록으로만 추가한다.
 
 ### REST API 설계
 
@@ -512,8 +534,8 @@ describe('ServiceName')         -- 서비스나 모듈 이름. 코드 식별자�
   describe('POST /resource')    -- 엔드포인트. 영어
     describe('methodName')      -- 메서드 이름. 코드 식별자이므로 영어
       describe('조건이 충족되면')  -- 조건. 한글로 작성
-        beforeEach(...)         -- 조건을 만드는 셋업
-        it('결과를 반환한다')      -- 결과 검증. 한글로 작성
+        beforeEach(...)         -- describe가 선언한 조건을 만듦
+        it('결과를 반환한다')      -- 동작 실행과 결과 검증. 한글로 작성
 ```
 
 세부 약속은 다음과 같다.
@@ -521,7 +543,11 @@ describe('ServiceName')         -- 서비스나 모듈 이름. 코드 식별자�
 - 최상위 `describe('ServiceName')`, HTTP 메서드/URL `describe('POST /resource')`, 메서드 이름 `describe('methodName')`처럼 코드 식별자를 가리키는 자리는 영어를 그대로 쓴다.
 - 조건을 표현하는 `describe`에는 한글 문자열을 직접 넣는다. `~할 때`, `~되었을 때`, `~않았을 때`처럼 절 형태로 적는다. 같은 내용을 주석으로 다시 쓰지 않는다.
 - 결과 검증을 표현하는 `it`에도 한글 문자열을 직접 넣는다. `~한다`, `~반환한다`, `~던진다`처럼 결과가 드러나게 적는다. HTTP 응답은 `~반환한다`, 서비스 계층의 예외는 `~던진다`로 구분한다. 부모 `describe`에 조건이 이미 있으면 `it` 메시지에서 조건을 반복하지 않는다.
-- 여러 `it`이 같은 조건을 공유하거나 시나리오에 설명이 필요하면 조건 `describe`로 묶고 그 `beforeEach`에서 조건을 만든다. `it` 하나뿐인 단발 조건은 `it` 문장에 `~면` 절로 싣고 본문에서 만든다.
+- 조건을 `describe('~면')`으로 선언했으면 그 조건은 반드시 해당 범위의 before hook에서 만든다. 기본은 `beforeEach`이며, 제목에만 조건을 적고 각 `it` 안에서 조건 준비를 반복하지 않는다. 검증 대상 동작과 결과 검증은 기본적으로 `it`이 맡는다. 다만 조건 자체가 만료나 실패 같은 상태 전이를 포함하면 before hook이 그 동작까지 수행하고 `it`은 결과만 관찰해도 된다. `it` 하나뿐인 단발 조건은 `it` 문장에 `~면` 절로 싣고 본문에서 만들어도 된다.
+- 조건을 만드는 비용이 크더라도 여러 `it`이 같은 시나리오를 다시 실행하는 것은 자연스러운 테스트 문장을 위한 의도된 중복이다. 실행 횟수를 줄이려고 서로 다른 결과를 한 `it`으로 기계적으로 합치지 않는다.
+- 조건형 `describe` 아래의 `it`은 제목이 이어져 `조건이 충족되면 결과를 반환한다`처럼 읽히게 쓴다. 본문에서는 보통 동작을 실행하고 그 결과를 검증한다. 그래서 주된 `expect`가 하나인 경우가 많지만 개수를 규칙으로 강제하지는 않는다. 하나의 결과를 설명하는 객체 형태나 복합 불변식에는 여러 matcher가 필요할 수 있다. 메서드·엔드포인트처럼 주제만 묶는 `describe` 바로 아래의 단발 조건은 `it` 본문에서 준비하고 동작시켜도 된다.
+- 테스트 시나리오의 `beforeAll`은 여러 `it`이 순서를 가지고 하나의 흐름을 이어서 검증할 때만 사용한다. 예를 들어 예매 흐름의 단계별 결과를 차례로 확인하는 경우다. 이때는 `describe.sequential`처럼 순차 실행을 코드로 명시하고, 선행 `it` 실패가 후속 `it`에 미치는 영향도 감수할 가치가 있어야 한다. 단순한 셋업 비용 절감에는 `beforeAll`을 사용하지 않는다.
+- 워커 단위 DB 연결이나 환경 검증처럼 테스트 하네스의 수명을 관리하는 전역 `beforeAll`은 시나리오 훅이 아니므로 이 규칙의 예외다.
 - 조건이 아니라 주제를 묶는 한글 명사구 `describe`도 쓴다(`'인가 경계'`, `'고객 예매 흐름'`). 절 형태 규칙은 조건을 표현하는 `describe`에만 적용된다.
 
 ### 픽스처 패턴
@@ -533,7 +559,7 @@ describe('UsersService', () => {
     let fix: AppTestContext
 
     beforeEach(async () => {
-        const { createAppTestContext } = await import('../helpers')
+        const { createAppTestContext } = await import('../helpers/index.js')
         fix = await createAppTestContext()
     })
 
@@ -557,7 +583,7 @@ describe('UsersService', () => {
 })
 ```
 
-PATCH나 DELETE처럼 상태를 바꾸는 API는 두 가지를 확인한다. 하나는 응답이 올바른지, 다른 하나는 DB 반영 여부다. 두 검증은 서로 다른 `it`으로 나눈다. 그래야 실패했을 때 어느 쪽 문제인지 바로 알 수 있다. DB 반영은 GET 재조회로 확인한다.
+PATCH나 DELETE처럼 상태를 바꾸는 API는 응답과 DB 반영을 각각 읽히는 `it`으로 나눈다. 같은 변경 요청이 반복되더라도 실패한 결과가 테스트 이름으로 바로 드러나는 쪽을 우선한다. DB 반영은 GET 재조회로 확인한다.
 
 ```ts
 describe('PATCH /theaters/:id', () => {
@@ -590,7 +616,7 @@ Nest 모듈 파일은 프로세스에서 한 번만 평가된다. 따라서 데�
 이 구조에서는 모듈 캐시를 테스트마다 초기화할 필요가 없다. 애플리케이션 코드와 Nest/Restate 의존성은 pool worker 안에서 한 번 로드되고, 테스트별 애플리케이션 컨텍스트만 새로 만든다. 픽스처는 정적으로 가져와도 자원 격리가 유지된다.
 
 ```ts
-import { createAppTestContext, type AppTestContext } from '../helpers'
+import { createAppTestContext, type AppTestContext } from '../helpers/index.js'
 
 describe('Users', () => {
     let fix: AppTestContext
@@ -632,7 +658,9 @@ pnpm --filter './apps/api' test users.spec --coverage.enabled=false
 pnpm --filter './apps/api' test users.spec -t '409 Conflict를 반환한다' --coverage.enabled=false
 ```
 
-devcontainer의 `firsttris.vscode-jest-runner`는 현재 Jest / Vitest Runner로 Vitest와 `node:test`를 자동 감지한다. 프로젝트에 Jest를 다시 설치하는 의존성이 아니며 파일·테스트 단위 실행과 디버깅에 사용하므로 유지한다.
+각 backend workspace의 `tsconfig.json`은 VS Code가 운영 소스와 테스트를 모두 같은 workspace 설정으로 해석할 수 있도록 둘 다 포함한다. 실제 검사는 `tsconfig.build.json`이 테스트를 제외한 운영 소스를, `tsconfig.test.json`이 Vitest 전역 타입을 포함한 테스트를 각각 맡는다. 편집기가 `describe`에서 `@types/jest` 설치를 권하거나 정상적인 `.js` 상대 경로와 `#core` 별칭을 찾지 못하면 Jest를 설치하지 말고 `TypeScript: Restart TS Server`를 한 번 실행한다.
+
+devcontainer의 `firsttris.vscode-jest-runner`는 현재 Jest / Vitest Runner로 Vitest와 `node:test`를 자동 감지한다. 이름에 Jest가 남아 있지만 프로젝트에 Jest를 다시 설치하는 의존성이 아니며 파일·테스트 단위 실행과 디버깅에 사용하므로 유지한다.
 
 ## 실행 가능한 API 문서
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -22,7 +22,7 @@ infra·deploy compose와 devcontainer는 같은 Docker 네트워크로 묶인다
 ## 부팅 순서
 
 1. `initializeCommand` — 사용자명과 workspace basename을 조합한 Docker 네트워크와 도구 설정 디렉터리 준비 (호스트에서 실행)
-2. 이미지 빌드 — patch·배포판·digest까지 고정한 Node 베이스에 현재 릴리스의 k6, cloudflared, shellcheck, lychee, PlantUML과 Playwright의 OS 의존성을 설치한다. 이 도구들은 폐기 가능한 개발 환경 도구이므로 Dockerfile에 개별 버전을 중복해서 고정하지 않는다.
+2. 이미지 빌드 — patch·배포판·digest까지 고정한 Node 베이스에 현재 릴리스의 k6, cloudflared, shellcheck, lychee, PlantUML과 Playwright의 OS 의존성을 설치한다. 이 도구들은 폐기 가능한 개발 환경 도구이므로 Dockerfile에 개별 버전을 중복해서 고정하지 않는다. 설치 명령의 실패가 빌드를 중단하므로 별도 `--version` 출력으로 다시 확인하지 않는다.
 3. `postCreateCommand` — `pnpm install --frozen-lockfile`(최초 1회) 후 lockfile의 Playwright와 일치하는 Chromium을 설치한다. manifest와 lockfile이 다르면 의존성 설치를 거부한다.
 4. `postStartCommand` — `bash infra/reset.sh`로 개발 인프라 기동 + PlantUML 서버
 

--- a/docs/reference/tutorial.md
+++ b/docs/reference/tutorial.md
@@ -331,7 +331,7 @@ describe('POST /showtime-creation/showtimes', () => {
     })
 ```
 
-`describe`·`it`이 함수 이름이 아니라 **동작과 조건**을 말한다 — 내부에서 검증·생성이 어떻게 쪼개지든 이 문장들은 그대로 유효하다. 조건은 `beforeEach`가 만들고 `it`은 검증만 한다. `waitForCompletion`은 SSE 스트림을 구독해 지정한 종결 상태가 올 때까지 기다리는 이 스위트의 유틸이고([showtime-creation.utils.ts](../../apps/api/src/__tests__/application/showtime-creation.utils.ts)), 단언은 서비스가 보고한 값이 아니라 **`sagaId`로 실제 DB를 재조회한 끝 상태**를 센다. 내부 함수를 호출했는지 검사하는 테스트는 없다 — 이 테스트가 성공하려면 사가 전체(202 → 워크플로 → SSE 이벤트)가 실제로 돌아야 한다.
+`describe`·`it`이 함수 이름이 아니라 **동작과 조건**을 말한다 — 내부에서 검증·생성이 어떻게 쪼개지든 이 문장들은 그대로 유효하다. 이 조건형 `describe`에서는 `beforeEach`가 조건을 만들고 `it`이 검증 대상 동작과 결과 검증을 맡는다. 조건 자체가 상태 전이를 포함하는 경우는 `beforeEach`가 그 동작까지 수행하고 `it`이 결과만 관찰해도 된다. 메서드나 엔드포인트처럼 주제만 묶는 `describe`의 단발 시나리오는 `it`이 조건 준비와 동작까지 맡을 수 있다. `waitForCompletion`은 SSE 스트림을 구독해 지정한 종결 상태가 올 때까지 기다리는 이 스위트의 유틸이고([showtime-creation.utils.ts](../../apps/api/src/__tests__/application/showtime-creation.utils.ts)), 단언은 서비스가 보고한 값이 아니라 **`sagaId`로 실제 DB를 재조회한 끝 상태**를 센다. 내부 함수를 호출했는지 검사하는 테스트는 없다 — 이 테스트가 성공하려면 사가 전체(202 → 워크플로 → SSE 이벤트)가 실제로 돌아야 한다.
 
 **실패 흐름(`failed`).** 검증 충돌은 400이 아니다 — 요청 자체는 접수(202)되고, 충돌 목록은 SSE로 온다.
 

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -34,7 +34,7 @@
 
 | 범위                              | 유지 | 보완 | 축소 | 제거 후보 |
 | --------------------------------- | ---: | ---: | ---: | --------: |
-| 표준 테스트 105개                 |   89 |    8 |    7 |         1 |
+| 표준 테스트 105개                 |   90 |    8 |    6 |         1 |
 | API 문서·race·benchmark·배포 24개 |   15 |    9 |    0 |         0 |
 
 전체적으로 단위·통합·브라우저·분산 race의 계층은 잘 나뉘어 있다. API 통합 테스트와 API 문서가 같은 endpoint를 호출하는 것, workflow 단위 테스트와 multi-replica race가 같은 불변식을 보는 것은 실행 경계가 달라 의도된 중복이다. 정리 효과가 큰 곳은 다음 다섯 군데다.
@@ -70,16 +70,16 @@ k6의 [`measurementStart()`](../tests/api-benchmark/perf-common.js)는 제거하
 
 현재 파일별 판단은 다음과 같다.
 
-| 파일                          |       현재 대기 | 판단                                                                                                                |
-| ----------------------------- | --------------: | ------------------------------------------------------------------------------------------------------------------- |
-| `jwt-auth.service.spec.ts`    |         4초 × 2 | 제거. 이미 만료된 JWT를 서명하는 fixture 하나로 두 오류 분기를 검증한다.                                            |
-| `ticket-holding.spec.ts`      |       1.5초 × 2 | 1회로 합친다. 한 번 만료시킨 뒤 빈 조회와 다른 고객의 선점 성공을 같이 확인한다.                                    |
-| `assets.spec.ts`              | 1~2.5초 여러 번 | S3 만료 대기는 유지한다. cron 실행 뒤의 1초 대기만 공개 메서드를 직접 `await`해서 없애고 중복 만료 케이스를 합친다. |
-| `cache.service.spec.ts`       |   1.5초 여러 번 | 유지. Redis 서버 TTL 자체가 검증 대상이며 polling으로 바꿔도 더 빨라지지 않는다.                                    |
-| `nats-pubsub.service.spec.ts` |        50~200ms | 유지. 도착은 이미 polling하고 있으며 남은 대기는 미수신을 관찰하는 상한이다.                                        |
-| logger 테스트 2개             |         30~50ms | 유지. 총 130ms를 없애려고 `performance.now()` 제어 코드를 추가할 실익이 없다.                                       |
-| `purchase-records.spec.ts`    |            50ms | 유지. 테스트 전용 생성 시각 인자나 Mongo 직접 수정보다 현재 방식이 작고 실제 정렬 경계에 가깝다.                    |
-| `showtime-creation.spec.ts`   |           5.1초 | 유지. Restate의 실제 5초 경계를 넘어야 완료 응답 유실 뒤 durable retry를 재현한다.                                  |
+| 파일                          |       현재 대기 | 판단                                                                                                                                                                            |
+| ----------------------------- | --------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jwt-auth.service.spec.ts`    |         4초 × 2 | 대기만 제거한다. 두 오류 분기는 별도 `it`으로 유지하고, 각 테스트가 이미 만료된 JWT fixture로 자기 메서드를 검증한다.                                                           |
+| `ticket-holding.spec.ts`      |       1.5초 × 2 | 유지. 만료 조건을 `beforeEach`에서 만들고 빈 조회와 다른 고객의 선점 성공을 각각 읽히는 `it`으로 검증한다. 두 검증은 순서가 있는 흐름이 아니므로 `beforeAll`로 공유하지 않는다. |
+| `assets.spec.ts`              | 1~2.5초 여러 번 | S3 만료 대기는 유지한다. 서로 다른 만료 결과는 별도 `it`으로 두고, cron 실행 뒤의 1초 대기만 공개 메서드를 직접 `await`해서 없앤다.                                             |
+| `cache.service.spec.ts`       |   1.5초 여러 번 | 유지. Redis 서버 TTL 자체가 검증 대상이며 polling으로 바꿔도 더 빨라지지 않는다.                                                                                                |
+| `nats-pubsub.service.spec.ts` |        50~200ms | 유지. 도착은 이미 polling하고 있으며 남은 대기는 미수신을 관찰하는 상한이다.                                                                                                    |
+| logger 테스트 2개             |         30~50ms | 유지. 총 130ms를 없애려고 `performance.now()` 제어 코드를 추가할 실익이 없다.                                                                                                   |
+| `purchase-records.spec.ts`    |            50ms | 유지. 테스트 전용 생성 시각 인자나 Mongo 직접 수정보다 현재 방식이 작고 실제 정렬 경계에 가깝다.                                                                                |
+| `showtime-creation.spec.ts`   |           5.1초 | 유지. Restate의 실제 5초 경계를 넘어야 완료 응답 유실 뒤 durable retry를 재현한다.                                                                                              |
 
 ### `configuration-contract.test.mjs` 16개 항목 상세
 
@@ -166,7 +166,7 @@ k6의 [`measurementStart()`](../tests/api-benchmark/perf-common.js)는 제거하
 - [`src/__tests__/core/theaters.spec.ts`](../apps/api/src/__tests__/core/theaters.spec.ts) — 극장 CRUD와 목록 조회를 검증한다.
   **판정: 유지 · 시드: 예제.**
 - [`src/__tests__/core/ticket-holding.spec.ts`](../apps/api/src/__tests__/core/ticket-holding.spec.ts) — 좌석 선점, 기존 선점 처리, 선점 조회와 구매 claim을 검증한다.
-  **판정: 축소 · 시드: 예제.** Redis TTL 검증 한 번은 유지하되, 같은 1.5초 대기를 두 번 하지 말고 한 만료 뒤 빈 조회와 다른 고객의 선점 성공을 함께 단언한다.
+  **판정: 유지 · 시드: 예제.** Redis TTL 만료 조건을 `beforeEach`에서 두 번 만들더라도 빈 조회와 다른 고객의 선점 성공을 별도 `it`으로 유지한다. 두 검증은 순서를 가진 하나의 흐름이 아니므로 `beforeAll` 공유 대상이 아니다.
 - [`src/__tests__/core/tickets.spec.ts`](../apps/api/src/__tests__/core/tickets.spec.ts) — 티켓 생성·검색·판매 원자 전이와 매출 집계를 검증한다.
   **판정: 유지 · 시드: 예제.**
 - [`src/__tests__/core/user-auth.spec.ts`](../apps/api/src/__tests__/core/user-auth.spec.ts) — 사용자 로그인, 내 정보, 계정 수정·삭제, 구매 목록, refresh, logout과 logout-all을 검증한다.
@@ -176,7 +176,7 @@ k6의 [`measurementStart()`](../tests/api-benchmark/perf-common.js)는 제거하
 - [`src/__tests__/core/watch-records.spec.ts`](../apps/api/src/__tests__/core/watch-records.spec.ts) — 시청 기록 생성과 페이지 검색을 검증한다.
   **판정: 유지 · 시드: 예제.**
 - [`src/__tests__/infrastructure/assets.spec.ts`](../apps/api/src/__tests__/infrastructure/assets.spec.ts) — 업로드 URL 생성·만료, 완료 확인·확정, 조회·삭제와 만료 업로드 정리를 검증한다.
-  **판정: 축소 · 시드: 핵심.** S3 presigned URL과 실제 만료 경계의 대기는 유지한다. 만료 fixture를 공유해 중복 케이스를 합치고, cron callback 뒤 1초 sleep 대신 `cleanupExpiredUploads()`를 직접 await해 코드와 시간 모두 줄인다.
+  **판정: 축소 · 시드: 핵심.** S3 presigned URL과 서로 다른 만료 결과의 독립된 테스트는 유지한다. cron callback 뒤 1초 sleep만 `cleanupExpiredUploads()`를 직접 await해 없앤다.
 - [`src/__tests__/infrastructure/payments.spec.ts`](../apps/api/src/__tests__/infrastructure/payments.spec.ts) — 결제 생성·취소와 구매별 조회를 검증한다.
   **판정: 유지 · 시드: 예제.**
 - [`src/__tests__/view/home.spec.ts`](../apps/api/src/__tests__/view/home.spec.ts) — 사용자 홈의 가까운 상영과 구성 결과를 검증한다.
@@ -230,7 +230,7 @@ k6의 [`measurementStart()`](../tests/api-benchmark/perf-common.js)는 제거하
 - [`src/auth/__tests__/guards.spec.ts`](../libs/common/src/auth/__tests__/guards.spec.ts) — Bearer, Basic, 복합·optional 인증 guard의 헤더 파싱과 오류 경계를 검증한다.
   **판정: 유지 · 시드: 핵심.**
 - [`src/auth/__tests__/jwt-auth.service.spec.ts`](../libs/common/src/auth/__tests__/jwt-auth.service.spec.ts) — access/refresh 발급, 원자 refresh 회전, 폐기, 전체 로그아웃과 보안 이벤트를 검증한다.
-  **판정: 보완 · 시드: 핵심.** 전역 시간을 바꾸지 않고 `expiresIn: '-1s'`인 유효한 refresh token fixture를 두 만료 분기에서 재사용하면 8초 대기와 프로덕션 변경을 모두 피할 수 있다.
+  **판정: 보완 · 시드: 핵심.** 전역 시간을 바꾸지 않고 각 만료 분기가 `expiresIn: '-1s'`인 유효한 refresh token fixture를 사용하면 별도 `it`을 합치지 않고도 8초 대기와 프로덕션 변경을 모두 피할 수 있다.
 - [`src/cache/__tests__/cache.service.spec.ts`](../libs/common/src/cache/__tests__/cache.service.spec.ts) — Redis cache set/delete/script, lock·blocking lock, 복구와 namespace 격리를 검증한다.
   **판정: 유지 · 시드: 핵심.** Redis 서버의 TTL과 lock 소유권 만료가 검증 대상이므로 real sleep을 유지한다. polling은 만료 시점을 앞당기지 못하고 코드만 늘린다.
 - [`src/config/__tests__/base-config.service.spec.ts`](../libs/common/src/config/__tests__/base-config.service.spec.ts) — 문자열·숫자·boolean 환경 설정 조회와 오류를 검증한다.

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -12,7 +12,7 @@
         "build": "tsc -p tsconfig.build.json",
         "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
         "test": "vitest run --coverage",
-        "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ vitest.config.mjs && prettier --check src/ vitest.config.mjs",
+        "lint": "tsc --noEmit -p tsconfig.build.json && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ vitest.config.mjs && prettier --check src/ vitest.config.mjs",
         "format": "prettier --write src/ vitest.config.mjs",
         "atoz": "pnpm run build && pnpm run lint && pnpm test"
     },

--- a/libs/common/src/auth/__tests__/guards.fixture.ts
+++ b/libs/common/src/auth/__tests__/guards.fixture.ts
@@ -2,9 +2,7 @@ import { createHttpTestContext, HttpTestClient } from '@mannercode/testing'
 import { Controller, Get, Injectable, UseGuards } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { JwtModule, JwtService } from '@nestjs/jwt'
-import { AuthGuard } from '../auth.guard.js'
-import { OptionalAuth } from '../optional-auth.decorator.js'
-import { Public } from '../public.decorator.js'
+import { AuthGuard, OptionalAuth, Public } from '../index.js'
 
 const TEST_SECRET = 'test-secret'
 

--- a/libs/common/src/auth/__tests__/guards.spec.ts
+++ b/libs/common/src/auth/__tests__/guards.spec.ts
@@ -1,6 +1,6 @@
 import { Reflector } from '@nestjs/core'
 import { JwtService } from '@nestjs/jwt'
-import { AuthGuard } from '../auth.guard.js'
+import { AuthGuard } from '../index.js'
 import { basicHeader, createGuardsFixture, type GuardsFixture } from './guards.fixture.js'
 
 describe('AuthGuard', () => {

--- a/libs/common/src/config/__tests__/base-config.service.fixture.ts
+++ b/libs/common/src/config/__tests__/base-config.service.fixture.ts
@@ -2,7 +2,7 @@ import { createTestContext } from '@mannercode/testing'
 import { Injectable } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { z } from 'zod'
-import { BaseConfigService } from '../base-config.service.js'
+import { BaseConfigService } from '../index.js'
 
 const configSchema = z.object({
     TEST_BOOLEAN_FALSE_KEY: z

--- a/libs/common/src/config/__tests__/base-config.service.spec.ts
+++ b/libs/common/src/config/__tests__/base-config.service.spec.ts
@@ -1,6 +1,6 @@
 import type { ConfigService } from '@nestjs/config'
 import type { BaseConfigServiceFixture } from './base-config.service.fixture.js'
-import { BaseConfigService } from '../base-config.service.js'
+import { BaseConfigService } from '../index.js'
 
 describe('BaseConfigService', () => {
     let fix: BaseConfigServiceFixture

--- a/libs/common/src/date-time-range/__tests__/date-time-range.spec.ts
+++ b/libs/common/src/date-time-range/__tests__/date-time-range.spec.ts
@@ -1,4 +1,4 @@
-import { DateTimeRange } from '../date-time-range.js'
+import { DateTimeRange } from '../index.js'
 
 describe('DateTimeRange', () => {
     const instant = (value: string) => Temporal.Instant.from(value)

--- a/libs/common/src/health/__tests__/nats.health-indicator.fixture.ts
+++ b/libs/common/src/health/__tests__/nats.health-indicator.fixture.ts
@@ -1,6 +1,6 @@
 import { createTestContext } from '@mannercode/testing'
 import { getNatsConnectionToken, NatsModule, type NatsConnection } from '../../nats/index.js'
-import { NatsHealthIndicator } from '../nats.health-indicator.js'
+import { NatsHealthIndicator } from '../index.js'
 
 export type NatsHealthIndicatorFixture = {
     connection: NatsConnection

--- a/libs/common/src/health/__tests__/redis.health-indicator.fixture.ts
+++ b/libs/common/src/health/__tests__/redis.health-indicator.fixture.ts
@@ -1,7 +1,7 @@
 import type { Redis } from 'ioredis'
 import { createTestContext } from '@mannercode/testing'
 import { getRedisConnectionToken, RedisModule } from '../../redis/index.js'
-import { RedisHealthIndicator } from '../redis.health-indicator.js'
+import { RedisHealthIndicator } from '../index.js'
 
 export type RedisHealthIndicatorFixture = {
     redis: Redis

--- a/libs/common/src/idempotency/__tests__/errors.spec.ts
+++ b/libs/common/src/idempotency/__tests__/errors.spec.ts
@@ -1,4 +1,4 @@
-import { IdempotencyErrors } from '../errors.js'
+import { IdempotencyErrors } from '../index.js'
 
 describe('IdempotencyErrors', () => {
     it('공통 HTTP 멱등성 오류 계약을 제공한다', () => {

--- a/libs/common/src/lat-long/__tests__/lat-long.fixture.ts
+++ b/libs/common/src/lat-long/__tests__/lat-long.fixture.ts
@@ -1,6 +1,6 @@
 import { HttpTestClient, createHttpTestContext } from '@mannercode/testing'
 import { Controller, Get } from '@nestjs/common'
-import { LatLong, ParseLatLongQuery } from '../lat-long.js'
+import { LatLong, ParseLatLongQuery } from '../index.js'
 
 export type LatLongFixture = { httpClient: HttpTestClient; teardown: () => Promise<void> }
 

--- a/libs/common/src/lat-long/__tests__/lat-long.spec.ts
+++ b/libs/common/src/lat-long/__tests__/lat-long.spec.ts
@@ -1,5 +1,5 @@
 import type { LatLongFixture } from './lat-long.fixture.js'
-import { LatLong, LatLongErrors } from '../lat-long.js'
+import { LatLong, LatLongErrors } from '../index.js'
 
 describe('LatLong', () => {
     let fix: LatLongFixture

--- a/libs/common/src/logger/__tests__/app-logger.service.spec.ts
+++ b/libs/common/src/logger/__tests__/app-logger.service.spec.ts
@@ -1,5 +1,5 @@
 import winston from 'winston'
-import { AppLoggerService } from '../app-logger.service.js'
+import { AppLoggerService } from '../index.js'
 
 describe('AppLoggerService', () => {
     let appLoggerService: AppLoggerService

--- a/libs/common/src/logger/__tests__/create-winston-logger.spec.ts
+++ b/libs/common/src/logger/__tests__/create-winston-logger.spec.ts
@@ -1,5 +1,5 @@
 import type winston from 'winston'
-import { createWinstonLogger } from '../create-winston-logger.js'
+import { createWinstonLogger } from '../index.js'
 
 const MESSAGE = Symbol.for('message')
 

--- a/libs/common/src/logger/__tests__/exception-logger.filter.fixture.ts
+++ b/libs/common/src/logger/__tests__/exception-logger.filter.fixture.ts
@@ -13,8 +13,7 @@ import {
 } from '@nestjs/common'
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core'
 import { sleep } from '../../utils/index.js'
-import { HttpExceptionLoggerFilter } from '../exception-logger.filter.js'
-import { HttpSuccessLoggerInterceptor } from '../success-logger.interceptor.js'
+import { HttpExceptionLoggerFilter, HttpSuccessLoggerInterceptor } from '../index.js'
 
 export type ExceptionLoggerFilterFixture = {
     httpClient: HttpTestClient

--- a/libs/common/src/logger/__tests__/exception-logger.filter.spec.ts
+++ b/libs/common/src/logger/__tests__/exception-logger.filter.spec.ts
@@ -1,5 +1,5 @@
 import type { ArgumentsHost } from '@nestjs/common'
-import type { HttpExceptionLoggerFilter } from '../exception-logger.filter.js'
+import type { HttpExceptionLoggerFilter } from '../index.js'
 import type { ExceptionLoggerFilterFixture } from './exception-logger.filter.fixture.js'
 
 describe('HttpExceptionLoggerFilter', () => {
@@ -12,7 +12,7 @@ describe('HttpExceptionLoggerFilter', () => {
     })
     afterEach(() => fix.teardown())
 
-    describe('HTTP 컨텍스트일 때', () => {
+    describe('HTTP 컨텍스트', () => {
         it('HttpException이 발생하면 Logger.warn으로 로그를 남긴다', async () => {
             await fix.httpClient
                 .get('/exception')
@@ -117,7 +117,7 @@ describe('HttpExceptionLoggerFilter', () => {
         let fakeHost: ArgumentsHost
 
         beforeEach(async () => {
-            const { HttpExceptionLoggerFilter } = await import('../exception-logger.filter.js')
+            const { HttpExceptionLoggerFilter } = await import('../index.js')
             filter = new HttpExceptionLoggerFilter()
             fakeHost = {
                 getType: () => 'rpc',

--- a/libs/common/src/logger/__tests__/redact.spec.ts
+++ b/libs/common/src/logger/__tests__/redact.spec.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb'
-import { redactSensitive } from '../redact.js'
+import { redactSensitive } from '../index.js'
 
 describe('redactSensitive', () => {
     it('민감 키의 값을 [REDACTED]로 치환한다', () => {

--- a/libs/common/src/logger/__tests__/request-timing.spec.ts
+++ b/libs/common/src/logger/__tests__/request-timing.spec.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express'
-import { elapsedSinceRequestStart, markRequestStart } from '../request-timing.js'
+import { elapsedSinceRequestStart, markRequestStart } from '../index.js'
 
 describe('request-timing', () => {
     it('동시에 진행되는 두 요청은 각자의 시작 시각을 독립적으로 갖는다', async () => {

--- a/libs/common/src/logger/__tests__/success-logger.interceptor.fixture.ts
+++ b/libs/common/src/logger/__tests__/success-logger.interceptor.fixture.ts
@@ -2,7 +2,7 @@ import type { MockInstance } from 'vitest'
 import { HttpTestClient, createHttpTestContext } from '@mannercode/testing'
 import { Controller, Get, Post, Provider } from '@nestjs/common'
 import { APP_INTERCEPTOR } from '@nestjs/core'
-import { HttpSuccessLoggerInterceptor } from '../success-logger.interceptor.js'
+import { HttpSuccessLoggerInterceptor } from '../index.js'
 
 export type SuccessLoggerInterceptorFixture = {
     httpClient: HttpTestClient

--- a/libs/common/src/mongodb/__tests__/crud.repository.fixture.ts
+++ b/libs/common/src/mongodb/__tests__/crud.repository.fixture.ts
@@ -6,8 +6,12 @@ import {
     MongoClient,
     type UpdateFilter
 } from 'mongodb'
-import { CrudRepository, type CrudRepositoryOptions } from '../crud.repository.js'
-import { CrudDocument, type StoredDocument } from '../mongo.document.js'
+import {
+    CrudDocument,
+    CrudRepository,
+    type CrudRepositoryOptions,
+    type StoredDocument
+} from '../index.js'
 
 export class Sample extends CrudDocument {
     name: string

--- a/libs/common/src/mongodb/__tests__/crud.repository.spec.ts
+++ b/libs/common/src/mongodb/__tests__/crud.repository.spec.ts
@@ -1,9 +1,7 @@
 import type { Collection, IndexDescription, MongoClient } from 'mongodb'
 import { BadRequestException, Logger, NotFoundException } from '@nestjs/common'
 import { OrderDirection } from '../../pagination/index.js'
-import { CrudRepository } from '../crud.repository.js'
-import { MongoErrors } from '../errors.js'
-import { objectId } from '../mongo.util.js'
+import { CrudRepository, MongoErrors, objectId } from '../index.js'
 import {
     createMongoRepositoryFixture,
     type Sample,
@@ -13,11 +11,11 @@ import {
 describe('CrudRepository', () => {
     let fix: MongoRepositoryFixture
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         fix = await createMongoRepositoryFixture()
     })
 
-    afterAll(async () => {
+    afterEach(async () => {
         await fix.teardown()
     })
 

--- a/libs/common/src/mongodb/__tests__/mongo.util.spec.ts
+++ b/libs/common/src/mongodb/__tests__/mongo.util.spec.ts
@@ -14,7 +14,7 @@ import {
     plainDateFromMongo,
     QueryBuilder,
     withoutPublicId
-} from '../mongo.util.js'
+} from '../index.js'
 
 describe('ObjectId helpers', () => {
     it('새로운 문자열 ObjectId를 만든다', () => {

--- a/libs/common/src/nats/__tests__/nats-pubsub.service.fixture.ts
+++ b/libs/common/src/nats/__tests__/nats-pubsub.service.fixture.ts
@@ -1,8 +1,11 @@
 import { createTestContext } from '@mannercode/testing'
-import type { NatsConnection } from '../nats.types.js'
-import { NatsPubSubModule, NatsPubSubService } from '../nats-pubsub.service.js'
-import { NatsModule } from '../nats.module.js'
-import { getNatsConnectionToken } from '../nats.tokens.js'
+import {
+    getNatsConnectionToken,
+    NatsModule,
+    NatsPubSubModule,
+    NatsPubSubService,
+    type NatsConnection
+} from '../index.js'
 
 export type NatsPubSubServiceFixture = {
     pubSubA: NatsPubSubService

--- a/libs/common/src/nats/__tests__/nats-pubsub.service.spec.ts
+++ b/libs/common/src/nats/__tests__/nats-pubsub.service.spec.ts
@@ -280,19 +280,19 @@ describe('NatsPubSubService', () => {
 
 describe('InjectNatsPubSub', () => {
     it('이름 없이 호출하면 파라미터 데코레이터를 반환한다', async () => {
-        const { InjectNatsPubSub } = await import('../nats-pubsub.service.js')
+        const { InjectNatsPubSub } = await import('../index.js')
         expect(typeof InjectNatsPubSub(undefined)).toBe('function')
     })
 
     it('이름과 함께 호출해도 파라미터 데코레이터를 반환한다', async () => {
-        const { InjectNatsPubSub } = await import('../nats-pubsub.service.js')
+        const { InjectNatsPubSub } = await import('../index.js')
         expect(typeof InjectNatsPubSub('my-bus')).toBe('function')
     })
 })
 
 describe('NatsPubSubModule.register', () => {
     it('기본 옵션으로 동적 모듈을 생성한다', async () => {
-        const { NatsPubSubModule } = await import('../nats-pubsub.service.js')
+        const { NatsPubSubModule } = await import('../index.js')
         const dynamicModule = NatsPubSubModule.register()
         expect(dynamicModule.module).toBe(NatsPubSubModule)
         expect(dynamicModule.providers?.length).toBe(1)

--- a/libs/common/src/nats/__tests__/nats.module.spec.ts
+++ b/libs/common/src/nats/__tests__/nats.module.spec.ts
@@ -1,8 +1,12 @@
 import { createTestContext } from '@mannercode/testing'
 import { Inject, Injectable, Module } from '@nestjs/common'
-import type { NatsConnection } from '../nats.types.js'
-import { NatsConnectionRegistry, NatsModule } from '../nats.module.js'
-import { DEFAULT_NATS_CONNECTION_NAME, getNatsConnectionToken } from '../nats.tokens.js'
+import {
+    DEFAULT_NATS_CONNECTION_NAME,
+    getNatsConnectionToken,
+    NatsConnectionRegistry,
+    NatsModule,
+    type NatsConnection
+} from '../index.js'
 
 @Injectable()
 class SiblingConsumer {

--- a/libs/common/src/pagination/__tests__/pagination.spec.ts
+++ b/libs/common/src/pagination/__tests__/pagination.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException } from '@nestjs/common'
 import type { PaginationFixture } from './pagination.fixture.js'
-import { CommonErrors } from '../../errors.js'
+import { CommonErrors } from '../../index.js'
 import { PaginationErrors, PaginationSchema } from '../index.js'
 
 describe('PaginationDto', () => {

--- a/libs/common/src/redis/__tests__/redis.module.fixture.ts
+++ b/libs/common/src/redis/__tests__/redis.module.fixture.ts
@@ -1,8 +1,6 @@
 import { createTestContext } from '@mannercode/testing'
 import { Inject, Injectable } from '@nestjs/common'
-import type { RedisConnection } from '../redis.types.js'
-import { RedisModule } from '../redis.module.js'
-import { getRedisConnectionToken } from '../redis.tokens.js'
+import { getRedisConnectionToken, RedisModule, type RedisConnection } from '../index.js'
 
 export type RedisModuleFixture = { redis: RedisConnection; teardown: () => Promise<void> }
 

--- a/libs/common/src/redis/__tests__/redis.module.spec.ts
+++ b/libs/common/src/redis/__tests__/redis.module.spec.ts
@@ -3,7 +3,7 @@ import type { RedisModuleFixture } from './redis.module.fixture.js'
 
 describe('RedisConnectionRegistry', () => {
     it('quit이 실패한 연결이 있어도 onModuleDestroy는 예외를 전파하지 않는다', async () => {
-        const { RedisConnectionRegistry } = await import('../redis.module.js')
+        const { RedisConnectionRegistry } = await import('../index.js')
         const registry = new RedisConnectionRegistry()
         const connection = { quit: vi.fn().mockRejectedValue(new Error('boom')) }
         registry.add(connection as any)

--- a/libs/common/src/utils/__tests__/async.spec.ts
+++ b/libs/common/src/utils/__tests__/async.spec.ts
@@ -1,4 +1,4 @@
-import { sleep } from '../async.js'
+import { sleep } from '../index.js'
 
 describe('sleep', () => {
     afterEach(() => {

--- a/libs/common/src/utils/__tests__/base64.spec.ts
+++ b/libs/common/src/utils/__tests__/base64.spec.ts
@@ -1,4 +1,4 @@
-import { Base64 } from '../base64.js'
+import { Base64 } from '../index.js'
 
 describe('Base64', () => {
     it('16진수 문자열을 base64로 변환한다', () => {

--- a/libs/common/src/utils/__tests__/byte.spec.ts
+++ b/libs/common/src/utils/__tests__/byte.spec.ts
@@ -1,4 +1,4 @@
-import { ByteUtil } from '../byte.js'
+import { ByteUtil } from '../index.js'
 
 describe('ByteUtil', () => {
     describe('fromString', () => {
@@ -46,7 +46,7 @@ describe('ByteUtil', () => {
             expect(ByteUtil.fromString('1gb')).toBe(1024 ** 3)
         })
 
-        describe('형식이 유효하지 않을 때', () => {
+        describe('유효하지 않은 형식', () => {
             it('알 수 없는 단어는 예외를 던진다', () => {
                 expect(() => ByteUtil.fromString('invalid')).toThrow()
             })

--- a/libs/common/src/utils/__tests__/checksum.spec.ts
+++ b/libs/common/src/utils/__tests__/checksum.spec.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises'
-import { Checksum, ChecksumSchema } from '../checksum.js'
-import { PathUtil } from '../path.js'
+import { Checksum, ChecksumSchema, PathUtil } from '../index.js'
 
 describe('Checksum', () => {
     describe('schema', () => {

--- a/libs/common/src/utils/__tests__/date.schema.spec.ts
+++ b/libs/common/src/utils/__tests__/date.schema.spec.ts
@@ -1,4 +1,4 @@
-import { InstantFromInputSchema, PlainDateFromInputSchema } from '../date.schema.js'
+import { InstantFromInputSchema, PlainDateFromInputSchema } from '../index.js'
 
 describe('Temporal input schemas', () => {
     it('지원 입력을 의미에 맞는 Temporal 타입으로 변환한다', () => {

--- a/libs/common/src/utils/__tests__/date.spec.ts
+++ b/libs/common/src/utils/__tests__/date.spec.ts
@@ -1,4 +1,4 @@
-import { DateUtil } from '../date.js'
+import { DateUtil } from '../index.js'
 
 describe('DateUtil', () => {
     describe('fromYMD', () => {

--- a/libs/common/src/utils/__tests__/env.spec.ts
+++ b/libs/common/src/utils/__tests__/env.spec.ts
@@ -1,4 +1,4 @@
-import { Env } from '../env.js'
+import { Env } from '../index.js'
 
 describe('Env', () => {
     describe('getString', () => {

--- a/libs/common/src/utils/__tests__/http.spec.ts
+++ b/libs/common/src/utils/__tests__/http.spec.ts
@@ -1,4 +1,4 @@
-import { HttpUtil } from '../http.js'
+import { HttpUtil } from '../index.js'
 
 describe('HttpUtil', () => {
     describe('buildContentDisposition', () => {

--- a/libs/common/src/utils/__tests__/id.spec.ts
+++ b/libs/common/src/utils/__tests__/id.spec.ts
@@ -1,4 +1,4 @@
-import { generateShortId, pickIds } from '../id.js'
+import { generateShortId, pickIds } from '../index.js'
 
 describe('generateShortId', () => {
     it('기본 15자 길이의 알파벳/숫자 ID를 생성한다', () => {

--- a/libs/common/src/utils/__tests__/json.spec.ts
+++ b/libs/common/src/utils/__tests__/json.spec.ts
@@ -1,4 +1,4 @@
-import { JsonUtil } from '../json.js'
+import { JsonUtil } from '../index.js'
 
 describe('JsonUtil', () => {
     describe('parse', () => {

--- a/libs/common/src/utils/__tests__/lodash.spec.ts
+++ b/libs/common/src/utils/__tests__/lodash.spec.ts
@@ -14,7 +14,7 @@ import {
     sortBy,
     sumBy,
     uniq
-} from '../lodash.js'
+} from '../index.js'
 
 const temporal = (
     globalThis as typeof globalThis & {

--- a/libs/common/src/utils/__tests__/path.spec.ts
+++ b/libs/common/src/utils/__tests__/path.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import os from 'os'
 import p from 'path'
-import { PathUtil } from '../path.js'
+import { PathUtil } from '../index.js'
 
 describe('PathUtil', () => {
     describe('getAbsolute', () => {

--- a/libs/common/src/utils/__tests__/time.spec.ts
+++ b/libs/common/src/utils/__tests__/time.spec.ts
@@ -1,4 +1,4 @@
-import { TimeUtil } from '../time.js'
+import { TimeUtil } from '../index.js'
 
 describe('TimeUtil', () => {
     describe('toMs', () => {

--- a/libs/common/src/utils/__tests__/validator.spec.ts
+++ b/libs/common/src/utils/__tests__/validator.spec.ts
@@ -1,6 +1,6 @@
 import type { MockInstance } from 'vitest'
 import { Logger } from '@nestjs/common'
-import { Assume, ensure, Require } from '../validator.js'
+import { Assume, ensure, Require } from '../index.js'
 
 describe('Require', () => {
     describe('defined', () => {

--- a/libs/common/tsconfig.build.json
+++ b/libs/common/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
     "extends": "./tsconfig.json",
-    "compilerOptions": { "noEmit": false, "paths": {}, "outDir": "_output/dist", "rootDir": "src" }
+    "compilerOptions": {
+        "noEmit": false,
+        "paths": {},
+        "outDir": "_output/dist",
+        "rootDir": "src",
+        "types": ["node"]
+    },
+    "exclude": ["src/**/__tests__/**"]
 }

--- a/libs/common/tsconfig.json
+++ b/libs/common/tsconfig.json
@@ -4,8 +4,8 @@
         "declaration": true,
         "declarationMap": true,
         "noEmit": true,
+        "types": ["node", "vitest/globals"],
         "paths": { "@mannercode/testing": ["../testing/src/index.ts"] }
     },
-    "include": ["src/**/*"],
-    "exclude": ["src/**/__tests__/**"]
+    "include": ["src/**/*"]
 }

--- a/libs/testing/package.json
+++ b/libs/testing/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
         "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
-        "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ vitest.config.mjs && prettier --check src/ vitest.config.mjs",
+        "lint": "tsc --noEmit -p tsconfig.build.json && tsc --noEmit -p tsconfig.test.json && oxlint -c ../../oxlint.json src/ vitest.config.mjs && prettier --check src/ vitest.config.mjs",
         "format": "prettier --write src/ vitest.config.mjs",
         "test": "vitest run",
         "atoz": "pnpm run build && pnpm run lint && pnpm test"

--- a/libs/testing/src/__tests__/create-test-context-cleanup.spec.ts
+++ b/libs/testing/src/__tests__/create-test-context-cleanup.spec.ts
@@ -15,7 +15,7 @@ describe('test context setup cleanup', () => {
             }
         }
 
-        const { createTestContext } = await import('../create-test-context.js')
+        const { createTestContext } = await import('../index.js')
         const result = createTestContext({ providers: [InitFailureProvider] })
 
         await expect(result).rejects.toBe(setupError)
@@ -33,7 +33,7 @@ describe('test context setup cleanup', () => {
             }
         }
 
-        const { createHttpTestContext } = await import('../create-http-test-context.js')
+        const { createHttpTestContext } = await import('../index.js')
         const result = createHttpTestContext({
             configureApp: async (createdApp) => {
                 app = createdApp
@@ -60,7 +60,7 @@ describe('test context setup cleanup', () => {
             }
         }
 
-        const { createTestContext } = await import('../create-test-context.js')
+        const { createTestContext } = await import('../index.js')
         const result = createTestContext({ providers: [SetupAndCleanupFailureProvider] })
 
         await expect(result).rejects.toBe(setupError)

--- a/libs/testing/src/__tests__/create-test-context.fixture.ts
+++ b/libs/testing/src/__tests__/create-test-context.fixture.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Injectable, Param } from '@nestjs/common'
-import { HttpTestClient } from '../http.test-client.js'
-import { createHttpTestContext } from '../index.js'
+import { createHttpTestContext, HttpTestClient } from '../index.js'
 
 export type TestContextFixture = {
     httpClient: HttpTestClient

--- a/libs/testing/src/__tests__/expect-equal-unsorted.spec.ts
+++ b/libs/testing/src/__tests__/expect-equal-unsorted.spec.ts
@@ -1,4 +1,4 @@
-import { expectEqualUnsorted } from '../expect-equal-unsorted.js'
+import { expectEqualUnsorted } from '../index.js'
 
 describe('expectEqualUnsorted', () => {
     it('객체 배열을 순서와 무관하게 같다고 판정한다', () => {

--- a/libs/testing/src/__tests__/http.test-client.fixture.ts
+++ b/libs/testing/src/__tests__/http.test-client.fixture.ts
@@ -12,8 +12,7 @@ import {
     Sse
 } from '@nestjs/common'
 import { Observable } from 'rxjs'
-import { HttpTestClient } from '../http.test-client.js'
-import { createHttpTestContext } from '../index.js'
+import { createHttpTestContext, HttpTestClient } from '../index.js'
 
 export type HttpTestClientFixture = { httpClient: HttpTestClient; teardown: () => Promise<void> }
 

--- a/libs/testing/src/__tests__/utils.spec.ts
+++ b/libs/testing/src/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { instant, isDebuggingEnabled, oid, plainDate, step, withTestId } from '../utils.js'
+import { instant, isDebuggingEnabled, oid, plainDate, step, withTestId } from '../index.js'
 
 describe('Temporal fixtures', () => {
     it('시각 문자열과 epoch 값을 밀리초 Instant로 만든다', () => {

--- a/libs/testing/tsconfig.build.json
+++ b/libs/testing/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
     "extends": "./tsconfig.json",
-    "compilerOptions": { "noEmit": false, "outDir": "_output/dist", "rootDir": "src" }
+    "compilerOptions": { "noEmit": false, "outDir": "_output/dist", "rootDir": "src" },
+    "exclude": ["src/**/__tests__/**"]
 }

--- a/libs/testing/tsconfig.json
+++ b/libs/testing/tsconfig.json
@@ -6,6 +6,5 @@
         "noEmit": true,
         "types": ["node", "vitest/globals"]
     },
-    "include": ["src/**/*"],
-    "exclude": ["src/**/__tests__/**"]
+    "include": ["src/**/*"]
 }

--- a/oxlint.json
+++ b/oxlint.json
@@ -22,6 +22,38 @@
     "ignorePatterns": ["**/_output/**", "**/.next/**", "**/coverage/**"],
     "overrides": [
         {
+            "files": [
+                "apps/api/src/**/__tests__/**/*.{spec,test,fixture}.ts",
+                "libs/*/src/**/__tests__/**/*.{spec,test,fixture}.ts"
+            ],
+            "rules": {
+                "no-restricted-imports": [
+                    "error",
+                    {
+                        "patterns": [
+                            {
+                                "group": [
+                                    "../*.js",
+                                    "../**/*.js",
+                                    "!../index.js",
+                                    "!../**/index.js",
+                                    // 공개 API가 아닌 구현 단위 테스트에서만 허용하는 직접 import다.
+                                    "!../booking.utils.js",
+                                    "!../temporal-json.serde.js",
+                                    "!../../services/core/movies/movies.repository.js",
+                                    "!../../services/core/movies/movie-pending-assets.repository.js",
+                                    "!../../services/core/purchase-records/purchase-records.repository.js",
+                                    "!../../services/core/tickets/tickets.repository.js",
+                                    "!../../services/infrastructure/payments/payments.repository.js"
+                                ],
+                                "message": "공개 항목은 해당 모듈의 index.js에서 가져오세요. 비공개 구현 테스트는 oxlint.json의 명시적 허용 목록에 추가하세요."
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
             "files": ["apps/{console,user-app}/src/**/*.{ts,tsx}"],
             "plugins": ["jsx-a11y", "nextjs", "react"],
             "rules": {

--- a/tools/__tests__/configuration-contract.test.mjs
+++ b/tools/__tests__/configuration-contract.test.mjs
@@ -60,7 +60,7 @@ test('workspaces share the Nest Oxlint baseline', async () => {
     }
 })
 
-test('devcontainer floats image tools while keeping project installs locked', async () => {
+test('devcontainer avoids redundant version probes while keeping project installs locked', async () => {
     const config = await read('.devcontainer/devcontainer.json')
     const dockerfile = await read('.devcontainer/Dockerfile')
     const lock = JSON.parse(await read('.devcontainer/devcontainer-lock.json'))
@@ -78,27 +78,28 @@ test('devcontainer floats image tools while keeping project installs locked', as
     assert.doesNotMatch(config, /initialize-user-state\.sh|devcontainerId/)
     assert.match(dockerfile, /^FROM node:\d+\.\d+\.\d+-bookworm-slim@sha256:[a-f0-9]{64}$/m)
     assert.doesNotMatch(dockerfile, /^ARG [A-Z_]+_VERSION=/m)
-
-    const assertVersionCheckedInInstallStep = (installMarker, versionMarker) => {
-        const installIndex = dockerfile.indexOf(installMarker)
-        const nextRunIndex = dockerfile.indexOf('\nRUN ', installIndex + 1)
-        const versionIndex = dockerfile.indexOf(versionMarker, installIndex)
-        assert.notEqual(installIndex, -1, `missing install marker: ${installMarker}`)
-        assert.ok(
-            versionIndex > installIndex && (nextRunIndex === -1 || versionIndex < nextRunIndex),
-            `${versionMarker} must be checked in its install step`
-        )
-    }
-    for (const [installMarker, versionMarker] of [
-        ['apt-get install -y --no-install-recommends', 'shellcheck --version'],
-        ['npm install --global --no-audit --no-fund playwright', 'playwright --version'],
-        ['releases/latest/download/plantuml.jar', 'java -jar /opt/plantuml.jar -version'],
-        ['releases/latest/download/${archive}.tar.gz', 'lychee --version'],
-        ['api.github.com/repos/grafana/k6/releases/latest', 'k6 version'],
-        ['releases/latest/download/cloudflared-linux-${TARGETARCH}', 'cloudflared --version'],
-        ['npm install --global --no-audit --no-fund pnpm', 'pnpm --version']
+    for (const versionProbe of [
+        'node --version',
+        'npm --version',
+        'curl --version',
+        'git --version',
+        'ip -Version',
+        'jq --version',
+        'shellcheck --version',
+        'shfmt -version',
+        'ssh -V',
+        'tmux -V',
+        'tree --version',
+        'unzip -v',
+        'xz --version',
+        'playwright --version',
+        'java -jar /opt/plantuml.jar -version',
+        'lychee --version',
+        'k6 version',
+        'cloudflared --version',
+        'pnpm --version'
     ]) {
-        assertVersionCheckedInInstallStep(installMarker, versionMarker)
+        assert.equal(dockerfile.includes(versionProbe), false, `redundant probe: ${versionProbe}`)
     }
     const configuredFeatures = Array.from(
         config.matchAll(/^\s*"(ghcr\.io\/[^"]+)"\s*:\s*\{/gm),

--- a/tools/__tests__/configuration-contract.test.mjs
+++ b/tools/__tests__/configuration-contract.test.mjs
@@ -135,6 +135,19 @@ test('backend workspaces use Node ESM and Vitest keeps the TypeScript metadata t
     const apiPackage = JSON.parse(await read('apps/api/package.json'))
     const commonPackage = JSON.parse(await read('libs/common/package.json'))
     const testingPackage = JSON.parse(await read('libs/testing/package.json'))
+    const parseTypeScriptConfig = (path) =>
+        typescript.getParsedCommandLineOfConfigFile(
+            join(root, path),
+            {},
+            {
+                ...typescript.sys,
+                onUnRecoverableConfigFileDiagnostic(diagnostic) {
+                    assert.fail(
+                        typescript.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+                    )
+                }
+            }
+        )
 
     assert.equal(rootTsconfig.compilerOptions.module, 'nodenext')
     assert.equal(rootTsconfig.compilerOptions.moduleResolution, 'nodenext')
@@ -157,18 +170,7 @@ test('backend workspaces use Node ESM and Vitest keeps the TypeScript metadata t
         'libs/common/tsconfig.test.json',
         'libs/testing/tsconfig.test.json'
     ]) {
-        const testTsconfig = typescript.getParsedCommandLineOfConfigFile(
-            join(root, path),
-            {},
-            {
-                ...typescript.sys,
-                onUnRecoverableConfigFileDiagnostic(diagnostic) {
-                    assert.fail(
-                        typescript.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
-                    )
-                }
-            }
-        )
+        const testTsconfig = parseTypeScriptConfig(path)
         assert.ok(testTsconfig)
         assert.equal(testTsconfig.options.module, typescript.ModuleKind.NodeNext)
         assert.equal(
@@ -177,6 +179,17 @@ test('backend workspaces use Node ESM and Vitest keeps the TypeScript metadata t
         )
         assert.equal(testTsconfig.options.isolatedModules, true)
         assert.deepEqual([...testTsconfig.options.types].sort(), ['node', 'vitest/globals'])
+    }
+
+    // VS Code는 이름이 tsconfig.json인 가장 가까운 project를 자동 선택한다.
+    // 편집용 project에는 테스트가 보여야 하고 실제 빌드에서는 빠져야 한다.
+    for (const workspace of ['apps/api', 'libs/common', 'libs/testing']) {
+        const editorTsconfig = parseTypeScriptConfig(`${workspace}/tsconfig.json`)
+        const buildTsconfig = parseTypeScriptConfig(`${workspace}/tsconfig.build.json`)
+        assert.ok(editorTsconfig)
+        assert.ok(buildTsconfig)
+        assert.ok(editorTsconfig.fileNames.some((path) => path.includes('/__tests__/')))
+        assert.ok(buildTsconfig.fileNames.every((path) => !path.includes('/__tests__/')))
     }
 
     for (const packageJson of [apiPackage, commonPackage, testingPackage]) {


### PR DESCRIPTION
## Summary

- migrate backend workspaces to native ESM/NodeNext and use runtime .js specifiers
- route tests through public index.js exports and enforce the convention with Oxlint
- align condition-based tests with describe/beforeEach/it responsibilities and document beforeAll limits
- remove redundant Dockerfile version probes after package installation

## Validation

- API targeted tests: 122 passed
- common targeted tests: 66 passed
- API/common/testing lint, test TypeScript, and build TypeScript checks passed
- root lint and configuration contract tests passed
- Dockerfile build check passed with no warnings