### PR TITLE
fix(ci): capture MongoDB and runner diagnostics for race failures

### DIFF
--- a/.github/workflows/test-api-race.yaml
+++ b/.github/workflows/test-api-race.yaml
@@ -24,7 +24,15 @@ jobs:
         runs-on: ubuntu-24.04-arm
         steps:
             - uses: actions/checkout@v7.0.1
+            # 호스트 지표는 Dev Container 밖에서 기록해야 runner 자원 경합을 볼 수 있다.
+            - name: Start runner diagnostics
+              id: runner_diagnostics
+              run: |
+                  command -v vmstat
+                  vmstat -w -t 1 > "${RUNNER_TEMP}/api-race-vmstat.log" 2>&1 &
+                  echo "$!" > "${RUNNER_TEMP}/api-race-vmstat.pid"
             - name: Run in devcontainer
+              id: race
               uses: devcontainers/ci@v0.3.1900000450
               with:
                   runCmd: |
@@ -35,3 +43,21 @@ jobs:
                           pnpm run race ${{ matrix.scenario }}
                           run=$((run + 1))
                       done
+            - name: Finish runner diagnostics
+              if: ${{ always() && steps.runner_diagnostics.outcome == 'success' }}
+              env:
+                  RACE_OUTCOME: ${{ steps.race.outcome }}
+              run: |
+                  kill "$(cat "${RUNNER_TEMP}/api-race-vmstat.pid")"
+                  if [ "${RACE_OUTCOME}" != "success" ]; then
+                      echo "=== runner resources $(date --utc --iso-8601=seconds) ==="
+                      head -n 3 "${RUNNER_TEMP}/api-race-vmstat.log"
+                      tail -n 180 "${RUNNER_TEMP}/api-race-vmstat.log"
+                      free -m
+                      df -h
+                      df -i
+                      for resource in cpu memory io; do
+                          echo "--- ${resource} pressure ---"
+                          cat "/proc/pressure/${resource}"
+                      done
+                  fi

--- a/.github/workflows/test-api-race.yaml
+++ b/.github/workflows/test-api-race.yaml
@@ -48,7 +48,6 @@ jobs:
               env:
                   RACE_OUTCOME: ${{ steps.race.outcome }}
               run: |
-                  kill "$(cat "${RUNNER_TEMP}/api-race-vmstat.pid")"
                   if [ "${RACE_OUTCOME}" != "success" ]; then
                       echo "=== runner resources $(date --utc --iso-8601=seconds) ==="
                       head -n 3 "${RUNNER_TEMP}/api-race-vmstat.log"
@@ -61,3 +60,4 @@ jobs:
                           cat "/proc/pressure/${resource}"
                       done
                   fi
+                  kill "$(cat "${RUNNER_TEMP}/api-race-vmstat.pid")"

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,8 @@ pnpm --filter './apps/api' test users.spec --coverage.enabled=false
 
 단위·통합 테스트와 race 결과는 터미널에서 확인한다. 브라우저 실패의 trace·screenshot·HTML은 `tests/web/_output/`에 남는다. benchmark는 실행 시각별 `tests/api/benchmark/_output/<YYYYMMDD-HHMMSS>/report.html`과 `summary.json`을 만든다.
 
+race 실패 로그에는 정리 전 컨테이너 상태·자원 사용량과 MongoDB 각 노드의 복제·서버 상태도 남긴다. Test API Race의 `Finish runner diagnostics`는 실패 직전 runner 자원 지표를 출력한다. 상태 조회는 실패 후의 snapshot이며, 복제 지연의 원인은 같은 시각의 DB 로그·runner 지표와 함께 판단한다.
+
 benchmark가 만든 극장 fixture는 개발 MongoDB에 남는다. 초기화하려면 `bash infra/reset.sh`를 실행한다.
 
 ## 3. 보조 명령

--- a/tests/api/race/runner.sh
+++ b/tests/api/race/runner.sh
@@ -51,14 +51,56 @@ cleanup() {
 trap cleanup EXIT
 
 dump_diagnostics() {
+    local service cid cname
+
     echo ""
     echo "=== container diagnostics ==="
+    date --utc --iso-8601=seconds
     "${compose[@]}" ps -a || true
+
+    timeout --kill-after=2s 10s "${compose[@]}" stats --all --no-stream --format json \
+        || echo "[diagnostics] container resource collection failed" >&2
+
     for cid in $("${compose[@]}" ps -aq 2>/dev/null); do
         cname=$(docker inspect --format '{{.Name}} ({{.State.Status}})' "${cid}" 2>/dev/null || echo "${cid}")
+        docker inspect --format 'name={{.Name}} state={{json .State}} restarts={{.RestartCount}}' "${cid}" \
+            || echo "[diagnostics] container state collection failed: ${cid}" >&2
         echo "--- logs ${cname} (last 200) ---"
         docker logs --tail 200 "${cid}" 2>&1 || true
         echo ""
+    done
+
+    # 복제 지연은 ping health만으로 알 수 없으므로 각 노드에 직접 상태를 묻는다.
+    # 상태 조회가 남기는 로그에 실패 직전 기록이 밀리지 않도록 기존 로그를 먼저 수집한다.
+    for service in mongo1 mongo2 mongo3; do
+        echo "--- MongoDB diagnostics: ${service} ---"
+        timeout --kill-after=2s 10s docker compose -f "${WORKSPACE_ROOT}/infra/compose.yml" \
+            exec -T "${service}" mongosh \
+            'mongodb://localhost:27017/?directConnection=true&serverSelectionTimeoutMS=2000&connectTimeoutMS=2000&socketTimeoutMS=5000' \
+            --quiet --eval '
+                print(EJSON.stringify({ replicaSet: db.adminCommand({ replSetGetStatus: 1 }) }))
+                const s = db.serverStatus()
+                print(EJSON.stringify({ server: {
+                    host: s.host,
+                    localTime: s.localTime,
+                    uptime: s.uptime,
+                    connections: s.connections,
+                    mem: s.mem,
+                    globalLock: s.globalLock,
+                    flowControl: s.flowControl,
+                    repl: s.metrics.repl,
+                    cache: {
+                        bytes: s.wiredTiger.cache["bytes currently in the cache"],
+                        maxBytes: s.wiredTiger.cache["maximum bytes configured"],
+                        dirtyBytes: s.wiredTiger.cache["tracked dirty bytes in the cache"],
+                        timeouts: s.wiredTiger.cache["operations timed out waiting for space in cache"]
+                    },
+                    journal: {
+                        syncs: s.wiredTiger.log["log sync operations"],
+                        syncMicros: s.wiredTiger.log["log sync time duration (usecs)"]
+                    }
+                } }))
+            ' </dev/null || echo "[diagnostics] MongoDB state collection failed: ${service}" >&2
     done
 }
 


### PR DESCRIPTION
API Race 실패 시 MongoDB의 복제 지연과 runner 자원 경합을 구분할 정보가 부족했습니다. 컨테이너 정리 전에 자원 사용량·OOM·재시작 상태와 MongoDB 각 노드의 복제·캐시·저널 지표를 수집하고, GitHub runner에서는 실행 중 vmstat를 기록해 실패 직전 구간과 메모리·디스크·pressure 지표를 출력합니다.

MongoDB 진단 조회는 제한 시간 안에서 수행하며 조회 실패를 별도로 표시합니다. 기존 오류 로그를 먼저 보존하고, 시나리오의 실패 결과와 반복 횟수·timeout은 유지합니다. 결과 확인 문서에 수집 위치와 실패 후 snapshot의 한계를 추가했습니다.

검증: 저장소 shellcheck, API 테스트 workspace lint, 변경 파일 format, workflow 내 shell 구문·shellcheck 통과. 실제 MongoDB 3개 노드와 컨테이너 자원 수집을 확인했고, 시나리오 설정 오류 시 진단 후 exit 1이 유지됨을 검증했습니다. 기존 Ubuntu 컨테이너의 실제 vmstat/free/df/pressure로 workflow 수집 스크립트의 성공·실패 경로도 실행했습니다.
